### PR TITLE
improvement: refactor from logdna/nodejs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,103 @@
+version: 2.1
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
+tagged_build_filters: &tagged_build_filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /v[0-9]+\.[0-9]+\.[0-9]+/
+test_build_filters: &test_build_filters
+  branches:
+    only: /.*/
+  tags:
+    ignore: /v[0-9]+\.[0-9]+\.[0-9]+/
+jobs:
+  test:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run lint
+      - run: npm run test
+      - coveralls/upload:
+          token: COVERALLS_REPO_TOKEN
+  build:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run:
+          name: Check Tagged Push
+          command: |
+            PKG_VERSION=$(grep version package.json | cut -d'"' -f4)
+            if [[ "${CIRCLE_TAG}" != "v${PKG_VERSION}" ]]; then
+              echo "There is mismatch:"
+              echo "  TAG_VERSION: ${CIRCLE_TAG}"
+              echo "  PKG_VERSION: v${PKG_VERSION}"
+              exit 1
+            fi
+      - run: npm install --production
+      - run: zip logdna.zip -r node_modules/ index.js package.json lib/*.js
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./logdna.zip
+  release:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - attach_workspace:
+          at: .
+      - run: go get -u github.com/tcnksm/ghr
+      - run:
+          name: Create a Release
+          command: |
+            ghr \
+              -n "LogDNA Node.js Logger ${CIRCLE_TAG}" \
+              -t ${GITHUB_TOKEN} \
+              -u ${CIRCLE_PROJECT_USERNAME} \
+              -r ${CIRCLE_PROJECT_REPONAME} \
+              -draft ${CIRCLE_TAG} ./logdna.zip
+  approve:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: .
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./logdna.zip
+  publish:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+      - run: npm publish
+workflows:
+  update:
+    jobs:
+      - test:
+          filters: *tagged_build_filters
+      - build:
+          requires:
+            - test
+          filters: *tagged_build_filters
+      - release:
+          requires:
+            - build
+          filters: *tagged_build_filters
+      - approve:
+          type: approval
+          requires:
+            - release
+          filters: *tagged_build_filters
+      - publish:
+          requires:
+            - approve
+          filters: *tagged_build_filters
+  test:
+    jobs:
+      - test:
+          filters: *test_build_filters

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,226 @@
+
+{
+  "root": true,
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "globals": {
+    "debug": false,
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2019,
+    "ecmaFeatures": {
+      "globalReturn": true
+    }
+  },
+  "plugins": [
+    "node",
+    "sensible"
+  ],
+  "rules": {
+    "accessor-pairs": 0,
+    "array-bracket-spacing": [2, "never"],
+    "array-callback-return": 2,
+    "arrow-parens": ["error", "as-needed", {
+      "requireForBlockBody": true
+    }],
+    "block-scoped-var": 2,
+    "block-spacing": [2, "always"],
+    "brace-style": [2, "1tbs", {
+      "allowSingleLine": true
+    }],
+    "class-methods-use-this": [0, {
+      "exceptMethods": []
+    }],
+    "comma-dangle": [2, "never"],
+    "comma-spacing": [2, {
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "first"],
+    "complexity": [0, 11],
+    "consistent-return": 0,
+    "consistent-this": [2, "that"],
+    "curly": [2, "multi-line"],
+    "default-case": 0,
+    "dot-location": [2, "property"],
+    "dot-notation": [2, {
+      "allowKeywords": true
+    }],
+    "eol-last": 2,
+    "eqeqeq": [2, "allow-null"],
+    "handle-callback-err": [2, "^(error|err|er)"],
+    "guard-for-in": 2,
+    "indent": 0,
+    "sensible/indent": [2, 2, {
+      "FunctionExpression": {
+        "parameters": "first"
+      },
+      "FunctionDeclaration": {
+        "parameters": "first",
+        "body": 1
+      },
+      "CallExpression": {
+        "arguments": "first"
+      },
+      "SwitchCase": 1
+    }],
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "keyword-spacing": [2, {
+      "overrides": {
+        "else": {
+          "before": true
+        },
+        "while": {
+          "before": true
+        },
+        "catch": {
+          "before": true
+        }
+      }
+    }],
+    "linebreak-style": ["error", "unix"],
+    "max-len": [2, 160, {
+      "ignoreComments": true
+    }],
+    "no-alert": 2,
+    "no-async-promise-executor": [2],
+    "no-caller": 2,
+    "no-case-declarations": 2,
+    "no-cond-assign": [2, "except-parens"],
+    "no-const-assign": "error",
+    "no-div-regex": 0,
+    "no-else-return": 0,
+    "no-empty-function": [2, {
+      "allow": ["arrowFunctions", "functions", "methods"]
+    }],
+    "no-empty-pattern": 2,
+    "no-eq-null": 2,
+    "no-eval": 2,
+    "no-extend-native": 2,
+    "no-extra-bind": 2,
+    "no-extra-label": 2,
+    "no-fallthrough": 1,
+    "no-floating-decimal": 2,
+    "no-global-assign": [2, {
+      "exceptions": []
+    }],
+    "no-implicit-coercion": [0, {
+      "boolean": false,
+      "number": true,
+      "string": true,
+      "allow": []
+    }],
+    "no-implicit-globals": 0,
+    "no-implied-eval": 2,
+    "no-invalid-this": 0,
+    "no-iterator": 2,
+    "no-labels": [2, {
+      "allowLoop": false,
+      "allowSwitch": false
+    }],
+    "no-loop-func": 2,
+    "no-mixed-spaces-and-tabs": 2,
+    "no-multi-spaces": 2,
+    "no-multi-str": 2,
+    "no-native-reassign": 0,
+    "no-new": 1,
+    "no-new-func": 2,
+    "no-new-wrappers": 2,
+    "no-new-object": 2,
+    "no-octal": 2,
+    "no-octal-escape": 2,
+    "no-param-reassign": 0,
+    "no-proto": 2,
+    "no-redeclare": 2,
+    "no-restricted-properties": [2, {
+      "object": "arguments",
+      "property": "callee",
+      "message": "arguments.callee is deprecated,"
+    }, {
+      "property": "__defineGetter__",
+      "message": "Please use Object.defineProperty instead."
+    }, {
+      "property": "__defineSetter__",
+      "message": "Please use Object.defineProperty instead."
+    }],
+    "no-return-assign": 2,
+    "no-return-await": 2,
+    "no-script-url": 2,
+    "no-self-assign": 2,
+    "no-self-compare": 2,
+    "no-sequences": 2,
+    "func-call-spacing": 2,
+    "no-tabs": [2],
+    "no-throw-literal": 2,
+    "no-trailing-spaces": [2],
+    "no-undef": [2],
+    "no-unmodified-loop-condition": 0,
+    "no-unreachable": [2],
+    "no-unused-expressions": [2, {
+      "allowShortCircuit": false,
+      "allowTernary": false
+    }],
+    "no-unused-labels": 2,
+    "no-unused-vars": [2, {
+      "vars": "all",
+      "args": "none"
+    }],
+    "no-use-before-define": [2, {
+      "functions": false
+    }],
+    "no-useless-call": 0,
+    "no-useless-concat": 2,
+    "no-useless-escape": 2,
+    "no-void": 2,
+    "no-warning-comments": [0, {
+      "terms": ["todo", "fixme", "xxx"],
+      "location": "start"
+    }],
+    "no-with": 2,
+    "node/no-deprecated-api": 2,
+    "object-curly-spacing": [2, "never"],
+    "object-shorthand": [2, "always"],
+    "one-var": [0, {
+      "uninitialized": "always",
+      "initialized": "never"
+    }],
+    "operator-linebreak": [2, "before"],
+    "padded-blocks": [0, "never"],
+    "prefer-const": 1,
+    "prefer-object-spread": [2],
+    "quote-props": [2, "consistent-as-needed", {
+      "keywords": true,
+      "unnecessary": false
+    }],
+    "quotes": [2, "single", "avoid-escape"],
+    "radix": 0,
+    "semi": [2, "never"],
+    "strict": [1, "global"],
+    "space-before-blocks": [2, "always"],
+    "space-before-function-paren": [2, {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
+    "space-in-parens": [2, "never"],
+    "space-infix-ops": 2,
+    "space-unary-ops": [2, {
+      "words": false,
+      "nonwords": false
+    }],
+    "spaced-comment": [2, "always"],
+    "vars-on-top": 0,
+    "wrap-iife": [2, "outside", {
+      "functionPrototypeMethods": false
+    }],
+    "yoda": 0,
+    "sensible/check-require": [2, "always"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+logs
+*.log
+npm-debug.log*
+coverage/
+node_modules/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,18 @@
+esm: false
+ts: false
+jsx: false
+check-coverage: true
+reporter: tap
+jobs: 2
+nyc-arg:
+- --all=true
+- --exclude=test/
+coverage-report:
+- text
+- text-summary
+- json
+- html
+files:
+- test/**/*.js
+100: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+This file documents all notable changes in the`LogDNA Node.js logger package`. The release numbering uses [semantic versioning](http://semver.org).
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 LogDNA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,504 @@
+<p align="center">
+  <a href="https://app.logdna.com">
+    <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
+  </a>
+  <p align="center">Node.js library for logging to <a href="https://logdna.com">LogDNA</a></p>
+</p>
+
+[![Coverage Status](https://coveralls.io/repos/github/logdna/logger-node/badge.svg?branch=master)](https://coveralls.io/github/logdna/logger-node?branch=master)
+---
+
+* **[Migrating From Other Versions](#migrating-from-other-versions)**
+* **[Install](#install)**
+* **[Setup](#setup)**
+* **[Usage](#usage)**
+* **[Supported Log Levels](#supported-log-levels)**
+* **[Convenience Methods](#convenience-methods)**
+* **[Events](#events)**
+    * [addMetaProperty](#event-addMetaProperty)
+    * [cleared](#event-cleared)
+    * [error](#event-error)
+        * [Error while sending to LogDNA](#error-while-sending-to-logdna)
+        * [Error while calling `log()`](#error-while-calling-log)
+    * [removeMetaProperty](#event-removeMetaProperty)
+    * [send](#event-send)
+    * [warn](#event-warn)
+        * [Warnings during `log()`](#warnings-during-log)
+        * [Warnings during `removeMetaProperty`](#warnings-during-removemetaproperty)
+* **[API](#api)**
+    * [createLogger](#createloggerkey-options)
+    * [setupDefaultLogger](#setupdefaultloggerkey-options)
+    * [logger.addMetaProperty](#loggeraddmetapropertykey-value)
+    * [logger.flush](#loggerflush)
+    * [logger.log](#loggerlogstatement-options)
+    * [logger.removeMetaProperty](#loggerremovemetapropertykey)
+* **[How Log Lines are Sent to LogDNA](#how-log-lines-are-sent-to-logdna)**
+* **[Exponential Backoff Strategy](#exponential-backoff-strategy)**
+* **[Best Practices](#best-practices)**
+* **[Client Side Support](#client-side)**
+* **[Bunyan Stream](#bunyan-stream)**
+* **[Winston Transport](#winston-transport)**
+* **[AWS Lambda Support](#aws-lambda-support)**
+* **[License](#license)**
+
+## Migrating From Other Versions
+
+Previous versions of this client are [still supported](https://github.com/logdna/nodejs), but if you are upgrading to this version, please see
+our [migration document](./docs/migrating-from-other-versions.md) for the differences between this version and prior versions.
+
+## Install
+
+```javascript
+$ npm install @logdna/logger
+```
+
+## Setup
+
+Operation requires a [LogDNA Ingestion Key](https://docs.logdna.com/docs/ingestion-key). Without it, the client will not be able to post
+logs to the cloud. Please contact our support if you have questions about this setup process!
+
+## Usage
+
+To use the client, create an instance, then call `.log()` or a [convenience method](#convenience-methods).
+
+```javascript
+const logdna = require('@logdna/logger')
+
+const options = {
+  app: 'myAppName'
+, level: 'debug' // set a default for when level is not provided in function calls
+}
+
+const logger = logdna.createLogger('<YOUR INGESTION KEY>', options)
+
+logger.log('This is an INFO statement', 'info')
+
+logger.log('This will be a DEBUG statement, based on the default')
+
+logger.log('This is an INFO statement with an options object', {
+  level: 'info'
+})
+
+logger.info('This is an INFO statement using a convenience method')
+
+logger.error('This is an error with meta data attached', {
+  indexMeta: true
+, meta: {
+    message: 'TypeError for XYZ'
+  , err
+  }
+})
+
+logger.error(err) // Objects can be logged too
+```
+
+## Supported Log Levels
+
+The client supports the following log levels. They are case-insensitive.
+
+* `TRACE`
+* `DEBUG`
+* `INFO`
+* `WARN`
+* `ERROR`
+* `FATAL`
+
+## Convenience Methods
+
+We have set up convenience methods that automatically set the log level appropriately, and are easy to read.
+
+### `logger.trace(msg[, options])`
+### `logger.debug(msg[, options])`
+### `logger.info(msg[, options])`
+### `logger.warn(msg[, options])`
+### `logger.error(msg[, options])`
+### `logger.fatal(msg[, options])`
+
+* `msg` [`<Object>`][] | [`<String>`][] - The message (or object) to log
+* `options` [`<Object>`][] - Per-message options. See [`logger.log()`](#loggerlogstatement-options) for those.
+
+## Events
+
+The `Logger` is an `EventEmitter` and will emit events rather than use promises or callbacks to communicate its progress.
+Listening to the events is optional, although an `error` listener is recommended.
+
+### Event: `'addMetaProperty'`
+
+* [`<Object>`][]
+    * `message` [`<String>`][] - Static message: `'Successfully added meta property'`
+    * `key` [`<String>`][] - The added key name
+    * `value` [`<String>`][] | [`<Number>`][] | [`<Boolean>`][] | [`<Object>`][] | [`<Array>`][] - The value
+
+Emitted when a meta property is successfully added. This meta property will be attached to each log message.
+
+### Event: `'cleared'`
+
+* [`<Object>`][]
+    * `message` [`<String>`][] - A message indicating that everything was sent or that nothing needed to be sent
+
+When all log lines have been sent to LogDNA, this event is emitted. If it emits after lines have successfully been sent,
+then the message will be `'All accumulated log entries have been sent'`. If there were no lines to be sent
+(for example, if `flush()` was called proactively), then the message will be `'All buffers clear; Nothing to send'`.
+
+
+### Event: `'error'`
+
+* [`<TypeError>`][] | [`<Error>`][]
+    * `message` [`<String>`][] - The error message
+    * `meta` [`<String>`][] - Meta object populated with different information depending on the error
+
+This event is emitted when an asynchronous error is encountered. Depending on the context, `meta` will contain
+different pieces of information about the error.
+
+#### Error while sending to LogDNA
+
+The metadata for an error encountered during an HTTP call to LogDNA will have the following `meta` properties in the error:
+
+* `actual` [`<String>`][] - The raw error message from the HTTP client
+* `code` [`<String>`][] | [`<Number>`][] - The HTTP agent's "code" or `statusCode` value
+* `firstLine` [`<String>`][] - The first log line in the buffer that was sending
+* `lastLine` [`<String>`][] - The last log line in the buffer that was sending
+* `retrying` [`<Boolean>`][] - Whether an attempt will be made to resend the payload
+* `attempts` [`<Number>`][] - The number of consecutive failures
+
+#### Error while calling `log()`
+
+When `log()` is called directly, or indirectly (via a convenience method), errors can be emitted if certain validations fail.
+If an invalid log level is provided, or if a bad data type is found for the `options` parameter, the `meta` property of the error
+will contain the following properties:
+
+* `got` [`<String>`][] - Description of the invalid input. Will depend on error context.
+* `expected` [`<String>`][] - The allowable log levels if `options` is an invalid log level
+* `used` [`<String>`][] - If a bad `level` is used in `options`, it will be ignored, and the default will be used.
+   This property indicates what that value is.
+
+
+### Event: `'removeMetaProperty'`
+
+* [`<Object>`][]
+    * `message` [`<String>`][] - Static message: `'Successfully removed meta property'`
+    * `key` [`<String>`][] - The key that was removed
+
+This is emitted when a key (and implied value) are removed from the global `meta` object. If the key does not exist,
+then a [`warn`](#event-warn) event with the same signature will be emitted instead.
+
+
+### Event: `'send'`
+
+* [`<Object>`][]
+    * `httpStatus` [`<String>`][] - The `status` property of the HTTP agent's response
+    * `firstLine` [`<String>`][] - The first log line in the buffer that was sent
+    * `lastLine` [`<String>`][] - The last log line in the buffer that was sent
+    * `totalLinesSent` [`<Number>`][] - The total number of lines in the sent buffer
+    * `totalLinesReady` [`<Number>`][] - The number of lines left to be sent (if queueing has happened)
+    * `bufferCount` [`<Number>`][] - The number of buffers left to be sent (if queueing has happened)
+
+This event is emitted when a buffer is successfully sent to LogDNA. Since a buffer can contain many log entries, this event summarizes the activity.
+In a high throughput system where `flushLimit` is exceeded and multiple buffers are waiting to be sent, information
+like `totalLinesReady` and `bufferCount` help illustrate how much work is left to be done. Any buffers that have been queued will
+be sent one after another, ignoring any flush timer.
+
+
+### Event: `'warn'`
+
+* [`<Object>`][]
+    * `message` [`<String>`][] - The warn message. Depends on context.
+
+This event is emitted when there is no log data provided to the `log` method, or when `removeMetaProperty` is called with an unrecognized key.
+For those cases, additional properties (apart from `message`) are included:
+
+#### Warnings during `log()`
+
+* `statement` (Any) - If `log()` was called with a `null` string or an invalid data type, this key will contain the given log statement.
+
+#### Warnings during `removeMetaProperty`
+
+* `key` [`<String>`][] - The key that the command attempted to remove but that did not exist
+
+## API
+
+### `createLogger(key[, options])`
+
+* `key` [`<String>`][] - Your [ingestion key](https://docs.logdna.com/docs/ingestion-key)
+* `options` [`<Object>`][]
+    * `level` [`<String>`][] - [Level](#supported-log-levels) to be used if not specified elsewhere. **Default:** `INFO`
+    * `tags` [`<Array>`][] | [`<String>`][] - Tags to be added to each message
+    * `meta` [`<Object>`][] - Global metadata. Added to each message, unless overridden.
+    * `timeout` [`<Number>`][] - Millisecond timeout for each HTTP request. **Default:** `5000`ms. **Max:** `300000`ms
+    * `hostname` [`<String>`][] - Hostname for each HTTP request.
+    * `mac` [`<String>`][] - MAC address for each HTTP request.
+    * `ip` [`<String>`][] - IPv4 or IPv6 address for each HTTP request.
+    * `url` [`<String>`][] - URL of the logging server. **Default:** `https://logs.logdna.com/logs/ingest`
+    * `flushLimit` [`<Number>`][] - Maximum total line lengths before a `flush` is forced. **Default:** `5000000`
+    * `flushIntervalMs` [`<Number>`][] - Mseconds to wait before sending the buffer. **Default:** `250`ms
+    * `shimProperties` [`<Array>`][] - List of dynamic `options` keys to look for when calling `log()`
+    * `indexMeta` [`<Boolean>`][] - Controls whether `meta` data for each message is searchable. **Default:** `false`
+    * `app` [`<String>`][] - Arbitrary app name for labeling each message. **Default:** `default`
+    * `env` [`<String>`][] - An environment label attached to each message
+    * `baseBackoffMs` [`<Number>`][] - Minimum exponential backoff time in milliseconds. **Default:** `3000`ms
+    * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
+    * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
+* Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]
+* Returns: `Logger`
+
+Returns a logging instance to use. `flushLimit` and `flushIntervalMs` control when the buffer is sent to LogDNA.
+The `flushIntervalMs` timer is only started after lines are logged, and the `flushLimit` is a size approximation based on the summation
+of `.length` properties of each log line. If the buffer size exceeds `flushLimit`, it will immediately send the buffer and ignore
+the `flushIntervalMs` timer. Otherwise, a timer will repeatedly flush the buffer every `flushIntervalMs` milliseconds,
+as long as the buffer contains log entries.
+
+If `indexMeta` is `false`, then the metadata will still appear in LogDNA search, but the fields themselves will not be searchable.
+If this option is `true`, then meta objects will be parsed and searchable up to three levels deep. Any fields
+deeper than three levels will be stringified and cannot be searched.
+**WARNING**: When this option is `true`, your metadata objects across all types of log messages *MUST* have consistent
+types, or the metadata object may not be parsed properly!
+
+`shimProperties` can be used to set up keys to look for in the `options` parameter of a `log()` call. If the specified keys
+are found in `options`, their key-values will be included the top-level of the final logging payload send to LogDNA.
+
+For more information on the backoff algorithm and the options for it, see the [Exponential Backoff Strategy](#exponential-backoff-strategy) section.
+
+
+### `setupDefaultLogger(key[, options])`
+
+The same as [`createLogger()`](#createloggerkey-options), except for that it creates a singleton that will be reused if called again.
+Users can call this multiple times, and the client package will maintain (create and/or return) the singleton.
+
+Note that only the first call will instantiate a new instance. Therefore, any successive calls will ignore the provided parameters.
+
+```javascript
+const logdna = require('@logdna/logger')
+
+const logger = logdna.setupDefaultLogger('<YOUR KEY HERE>')
+const sameLogger = logdna.setupDefaultLogger()
+```
+
+### `logger.addMetaProperty(key, value)`
+
+* `key` [`<String>`][] - The meta property's key
+* `value` [`<String>`][] | [`<Number>`][] | [`<Boolean>`][] | [`<Object>`][] | [`<Array>`][] - The meta property's value
+* Emits: [`addMetaProperty`](#event-addmetaproperty)
+
+This method adds a key-value to the global metadata, which is added to each log entry upon calling `log()`.
+Although `meta` can be set on instantiation, this method provides a way to update it on-the-fly.
+
+If `options.meta` is also used in a `log()` call, the key-value pairs from the global `meta` will be merged with
+`options.meta`, and those new pairs will take precedence over any matching keys in the global metadata.
+
+```javascript
+// This will use `meta` to track logs from different modules
+const logger = createLogger('<YOUR API KEY>', {
+  meta: {
+    module: 'main.js' // Global default
+  }
+})
+
+logger.debug('This is the main module') // Uses global meta
+
+// ... elsewhere, in another file, perhaps
+logger.info('I am in module1.js', {
+  meta: {module: __filename} // Overrides global meta
+})
+```
+
+### `logger.flush()`
+
+* Emits: [`cleared`](#event-cleared)
+
+When `flush` is called, any messages in the buffer are sent to LogDNA. It's not necessary to call this manually, although it is useful
+to do so to ensure clean shutdown (see [Best Practices](#best-practices)). When `log` is called, it automatically starts a timer
+that will call `flush`, but it is idempotent and can be called at any time.
+
+If log lines exist in the current buffer, it is pushed onto a send queue, and a new buffer is created. The send queue is processed and uploaded to LogDNA.
+
+If no work needs to be done, the `cleared` event is immediately emitted.
+
+### `logger.log(statement[, options])`
+
+* `statement` [`<String>`][] | [`<Object>`][] - Text or object of the log entry. Objects are serialized.
+* `options` [`<String>`][] | [`<Object>`][] - A string representing a [level](#supported-log-levels) or an object with the following elements:
+    * `level` [`<String>`][] - Desired [level](#supported-log-levels) for the current message. **Default:** `logger.level`
+    * `app` [`<String>`][] - App name to use for the current message. **Default:** `logger.app`
+    * `env` [`<String>`][] - Environement name to use for the current message. **Default:** `logger.env`
+    * `timestamp` [`<Number>`][] - Epoch ms time to use for the current message. Must be within 24 hours. **Default:** `Date.now()`
+    * `context` [`<Object>`][] - Synonym for `meta`, but mutually exclusive. Ignored if `meta` exists.
+    * `indexMeta` [`<Boolean>`][] - Allows for the `meta` to be searchable in LogDNA. **Default:** `logger.indexMeta`
+    * `meta` [`<Object>`][] - Per-message meta data. Combined with key-values created with `addMetaProperty`
+* Emits: [warn](#event-warn), [error](#event-error)
+
+Sends a string or object to LogDNA for storage. If the [convenience methods](#convenience-methods) are used, they call this function
+under the hood, so the options are the same. The only difference is that `level` is automatically set in the convenience methods.
+
+### `logger.removeMetaProperty(key)`
+
+* `key` [`<String>`][] - The key (and implied value) to be removed from the global `meta` object.
+* Emits: [`warn`](#event-warn)
+
+Attempts to remove the given key from the global `meta` data object. If the key is not found, `warn` is emitted.
+
+## How Log Lines are Sent to LogDNA
+
+In default operation, when `log` functions are called, the line is added to a buffer to cut down on HTTP traffic to the server.
+The buffer is flushed every `flushIntervalMs` milliseconds or if the log line lengths grow beyond `flushLimit`.
+
+When `flush` fires (or is called manually), the current buffer is put onto a send queue, and a new buffer is started. The send queue begins
+sending to LogDNA. It will continue to send without pausing or honoring `flushIntervalMs` as long as there are buffers in the send queue.
+When the send queue is empty, `cleared` is emitted.
+
+### Handling Errors
+
+* `timeout` or `500` errors will be retried using an [exponential backoff strategy](#exponential-backoff-strategy), but will
+  also emit `error` events along the way.
+* User-level errors (such as `400`) will not be retried because they most likely would never be successful (if the message is deemed invalid),
+  and `error` events are emitted for these errors, also.
+
+## Exponential Backoff Strategy
+
+When HTTP failures happen, if they are deemed "retryable" (non-user errors), then the client will pause for a short time before
+trying to resend. The algorithm it implements is an exponential backoff with a "jitter" strategy that uses random numbers statistically to
+spread out the wait times to avoid flooding.
+
+The settings for `baseBackoffMs` and `maxBackoffMs` are used in this algorithm and serve as the lower and upper boundaries for the wait time.
+
+These types of errors are blocking since they are related to timeouts and server errors. Logs will continue to buffer as normal, and
+if the HTTP calls becomes successful, they will begin to send immediately, and without pause.
+
+## Best Practices
+
+* The client is optimized for high throughput. Using a single instance is no problem, but multiple instances can be created with the same key if desired.
+* Set up an `error` listener so that your app is aware of problems. Things like HTTP errors are emitted this way.
+* When shutting down your application, ensure all log entries are cleared. Services like AWS Lambda can buffer log entries,
+  so it might be worthwhile to pause for a short time before exiting like in the following example:
+
+```javascript
+const {createLogger} = require('@logdna/logger')
+const {once} = require('events')
+
+const logger = createLogger('<YOUR KEY HERE>')
+
+logger.on('error', console.error)
+
+async function clearLogger() {
+  logger.flush()
+  await once(logger, 'cleared')
+  // Everything clear.  Did Lambda buffer anything?
+  await sleep(1000)
+  logger.flush()
+  await once(logger, 'cleared')
+}
+
+```
+
+## Client Side
+
+Browserify Example
+
+```javascript
+const {createLogger} = require('@logdna/logger');
+const logger = createLogger('API KEY HERE', {
+  hostname:'ClientSideTest'
+, app: 'sequence'
+, indexMeta: true
+})
+
+const date = new Date().toISOString()
+const logme = () => {
+  for (var i = 0; i < 10; i++) {
+    logger.log('Hello LogDNA Test ' + date, {
+      meta: {
+        sequence: i
+      }
+    })
+  }
+}
+
+setInterval(logme, 5000);
+```
+If the above snippet is saved as a file `main.js`, then, with Browserify, you can convert this file to a `bundle.js` file:
+```
+browserify main.js -o bundle.js
+```
+The `bundle.js` file can be included like any other script:
+```
+<script src="bundle.js"></script>
+```
+When using NodeJS inside a browser, the domain needs to be whitelisted in your LogDNA organization settings.
+
+## Bunyan Stream
+
+For Bunyan Stream support, reference our [logdna-bunyan](https://github.com/logdna/logdna-bunyan/) module.
+
+## Winston Transport
+
+For Winston support, reference our [logdna-winston](https://github.com/logdna/logdna-winston/) module.
+
+## AWS Lambda Support
+
+AWS Lambda allows users to add logging statements to their Lambda Functions. You can choose to setup the logger
+as shown above, or you can override the `console.log` and `console.error` statements. AWS Lambda overrides the `console.log`,
+`console.error`, `console.warn`, and `console.info` functions as indicated
+[here](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html), within the scope of the handler (main)
+function. You can setup an override as follows:
+
+```javascript
+'use strict'
+
+const https = require('https')
+const Logger = require('@logdna/logger')
+
+const options = {
+  env: 'env'
+, app: 'lambda-app'
+, hostname: 'lambda-test'
+, indexMeta: true
+}
+
+const _log = console.log
+const _error = console.error
+
+const logger = Logger.setupDefaultLogger('YOUR API KEY', options)
+
+function log(...args) {
+  logger.log.apply(args)
+  _log.apply(...args)
+}
+
+function error(...args) {
+  logger.error.apply(args)
+  _error.apply(args)
+}
+
+/**
+ * Pass the data to send as `event.data`, and the request options as
+ * `event.options`. For more information see the HTTPS module documentation
+ * at https://nodejs.org/api/https.html.
+ *
+ * Will succeed with the response body.
+ */
+exports.handler = (event, context, callback) => {
+  console.log = log
+  console.error = error
+
+  // Your code here
+  console.log('How bout normal log')
+  console.error('Try an error')
+
+  callback()
+}
+```
+
+
+## License
+
+Copyright © [LogDNA](https://logdna.com), released under an MIT license. See the [LICENSE](./LICENSE) file and https://opensource.org/licenses/MIT
+
+*Happy Logging!*
+
+[`<Boolean>`]: https://mdn.io/boolean
+[`<Number>`]: https://mdn.io/number
+[`<Object>`]: https://mdn.io/object
+[`<String>`]: https://mdn.io/string
+[`<Array>`]: https://mdn.io/array
+[`<TypeError>`]: https://mdn.io/TypeError
+[`<RangeError>`]: https://mdn.io/RangeError
+[`<Error>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/docs/migrating-from-other-versions.md
+++ b/docs/migrating-from-other-versions.md
@@ -1,0 +1,73 @@
+# Migrating From Other Versions
+----
+This client is an improved version of [a previous one](https://github.com/logdna/nodejs).
+We have changed the namespace and repository of this version for better continuity with other clients for our
+product.
+
+For most people, migrating to this from other versions will be relatively simple. The primary
+breaking change is the removal of callbacks in the client, which have been replaced by `EventEmitter` events.
+Other changes include the removal of cleanup functions for multiple client instances and the deprecation
+of several configuration properties.
+
+## Removal of Callbacks
+The `log` method used to accept a callback, and that has been removed.  This shouldn't be a problem for most
+upgrades since it was undocumented.  In any case, if you were using callbacks before, just move to using events.  
+See below for examples.
+
+## Log Instances are not Tracked
+The previous versions tracked log instances created with `createLogger()` in a privately-scoped variable in the
+client.  Its primary use was to support the `flushAll` and `cleanUpAll` functions which have been removed, so the
+client will no longer do this.  If you're only using a single instance of the logger, then this change does not affect you.
+
+If you are creating multiple instances of the logger, you will want to make sure they're independently cleared
+(by using the `cleared` event) upon shutdown, but that's really just a best practice.
+
+## `Logger` class is not exported
+We provide the helper functions `createLogger()` and `setupDefaultLogger()` for creating log instances.
+Therefore, the class itself does not need to be exported.
+
+## Removed Functions
+The following functions were removed
+
+* `flushAll` - This is no longer necessary because the client does not track multiple instances
+* `cleanUpAll` - This is no longer necessary for the same reasons as `flushAll`
+
+If you were using these functions, then they are easily replaced by calling `flush` manually, and awaiting the `cleared`
+event as described in our [Best Practices](../README#best-practices) recommendations.
+
+## `options` Key Name Changes
+All keys for supported options are now lowerCamelCase for consistency.  Old names have been deprecated and will still
+work, but a `console.warn` will be printed to inform the user to update them.  This is a list of those key name changes:
+
+* `logdna_url` is now just `url`
+* `index_meta` is now `indexMeta`
+* `with_credentials` is now `withCredentials`
+* `max_length` is no longer an option and will throw if used
+
+## What it Looks Like Now
+```javascript
+const {once} = require('events')
+const {createLogger} = require('@logdna/logger')
+
+const logger = createLogger('<YOUR KEY HERE>')
+
+// All events are optional, but an `error` is recommended
+logger.on('error', console.error)
+logger.on('warn', console.warn)
+
+async function clearLogging() {
+  logger.flush()
+  await once(logger, 'cleared')
+  // Everything clear.  Did Lambda buffer anything?
+  await sleep(1000)
+  logger.flush()
+  await once(logger, 'cleared')
+  return
+}
+
+logger.log('some log line')
+
+clearLogging().then(() => {
+  // All lines have been sent
+}).catch(() => {})  
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const Logger = require('./lib/logger.js')
+
+let singleton
+
+const setupDefaultLogger = function(key, opts) {
+  if (singleton) return singleton
+  singleton = new Logger(key, opts)
+  return singleton
+}
+
+function createLogger(key, options) {
+  return new Logger(key, options)
+}
+
+module.exports = {
+  createLogger
+, setupDefaultLogger
+}

--- a/lib/backoff-with-jitter.js
+++ b/lib/backoff-with-jitter.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * This implements exponential backoff with "decorrelated jitter" for use in
+ * failing HTTP calls and their retries.  Although the HTTP calls shouldn't be in
+ * contention with other clients, the jitter will help alleviate a flood
+ * of connections to the server in the event LogDNA suddenly comes back
+ * online after being unavailable.
+ *
+ * @see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ *
+ * @param   {Number} base The base sleep time to be used
+ * @param   {Number} cap The maximum sleep time allowable in milliseconds
+ * @param   {Number} lastSleep The last (or starting) sleep time used
+ * @returns {Number} calculated sleep time
+ */
+
+module.exports = function backoffWithJitter(base, cap, lastSleep) {
+  const sleep = Math.min(
+    cap
+  , _randomBetween(base, lastSleep * 3)
+  )
+  return sleep
+}
+
+function _randomBetween(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// Internal Modules
+const pkg = require('../package.json')
+
+module.exports = {
+  AGENT_SETTING: {maxSockets: 20, freeSocketTimeout: 60000}
+, BASE_BACKOFF_MILLIS: 3000
+, MAX_BACKOFF_MILLIS: 30000
+, DEFAULT_REQUEST_HEADER: {'Content-Type': 'application/json; charset=UTF-8'}
+, DEFAULT_REQUEST_TIMEOUT: 5000
+, USER_AGENT: `${pkg.name}/${pkg.version}`
+, FLUSH_BYTE_LIMIT: 5000000
+, FLUSH_INTERVAL_MS: 250
+, HOSTNAME_CHECK: /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/
+, LOG_LEVELS: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
+, LOGDNA_URL: 'https://logs.logdna.com/logs/ingest'
+, MAC_ADDR_CHECK: /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
+, MAX_INPUT_LENGTH: 80
+, MAX_LINE_LENGTH: 32000
+, MAX_REQUEST_TIMEOUT: 300000
+, MS_IN_A_DAY: 86400000
+, PROTOCOL_RE: /^https?:\/\//
+, REQUEST_WITH_CREDENTIALS: false
+, TAGS_RE: /\s*,\s*/
+}

--- a/lib/lang/type-of.js
+++ b/lib/lang/type-of.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * @module lib/lang/typeof
+ **/
+
+const TYPE_EXP = /^\[object (.*)\]$/
+const toString = Object.prototype.toString
+
+/**
+ * A more accurate version of the javascript built-in function typeof
+ * Date strings in ISO format are special cased to identify as `'date'`
+ * @function module:lib/lang/type-of
+ * @param {Any} value The javascript object to type check
+ * @returns {String} The type of the object passed in
+ * @example
+ * typeOf([]) // 'array'
+ * typeOf(/\w+/) // 'regexp'
+ * @example
+ * class FooBar {
+ *   get [Symbol.toStringTag]() {
+ *     return 'foobar'
+ *   }
+ * }
+ * typeOf(new FooBar()) // 'foobar'
+ **/
+
+module.exports = function typeOf(value) {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  const parts = TYPE_EXP.exec(toString.call(value))
+  return parts[1].toLowerCase()
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,653 @@
+'use strict'
+
+const EventEmitter = require('events')
+const os = require('os')
+const querystring = require('querystring')
+const {isIP} = require('net')
+const Agent = require('agentkeepalive')
+const axios = require('axios')
+const stringify = require('json-stringify-safe')
+const constants = require('./constants.js')
+const {checkStringParam, isValidTimestamp, has} = require('./validators/index.js')
+const backoffWithJitter = require('./backoff-with-jitter.js')
+const typeOf = require('./lang/type-of.js')
+
+const kLineLengthTotal = Symbol('lineLengthTotal')
+const kBuffer = Symbol('buffer')
+const kMeta = Symbol('meta')
+const kIsLoggingBackedOff = Symbol.for('isLoggingBackedOff')
+const kFlusher = Symbol('flusher')
+const kAttempts = Symbol('attempts')
+const kRequestDefaults = Symbol.for('requestDefaults')
+const kReadyToSend = Symbol.for('readyToSend')
+const kIsSending = Symbol.for('isSending')
+const kTotalLinesReady = Symbol.for('totalLinesReady')
+const kBackoffMs = Symbol('backoffMs')
+
+const ALL_CLEAR_SENT = 'All accumulated log entries have been sent'
+const ALL_CLEAR_EMPTY = 'All buffers clear; Nothing to send'
+const META_ADD_SUCCESS = 'Successfully added meta property'
+const WARN_LOG_IGNORED = 'Log statement was empty.  Ignored'
+const REMOVE_META_WARN = 'Property is not an existing meta property.  Cannot remove.'
+const REMOVE_META_SUCCESS = 'Successfully removed meta property'
+const ERROR_CODES_TO_RETRY = new Set([
+  500
+, 'ECONNABORTED' // timeout
+])
+
+class Logger extends EventEmitter {
+  constructor(key, opts) {
+    super()
+    const options = opts || {}
+
+    checkStringParam(key, 'LogDNA Ingestion Key', true)
+
+    // Defaults for instantiation parameters
+    this.level = 'INFO'
+    this.url = constants.LOGDNA_URL
+    this.flushLimit = constants.FLUSH_BYTE_LIMIT
+    this.flushIntervalMs = constants.FLUSH_INTERVAL_MS
+    this.shimProperties = undefined
+    this.indexMeta = false
+    this.app = 'default'
+    this.env = undefined
+    this.baseBackoffMs = constants.BASE_BACKOFF_MILLIS
+    this.maxBackoffMs = constants.MAX_BACKOFF_MILLIS
+
+    // Initialize internal instance variables
+    this[kLineLengthTotal] = 0
+    this[kBuffer] = []
+    this[kMeta] = {}
+    this[kIsLoggingBackedOff] = false
+    this[kAttempts] = 0
+    this[kRequestDefaults] = undefined
+    this[kFlusher] = null
+    this[kReadyToSend] = []
+    this[kIsSending] = false
+    this[kTotalLinesReady] = 0
+    this[kBackoffMs] = constants.BASE_BACKOFF_MILLIS
+
+    let useHttps = true
+    let withCredentials = false
+    let tags = undefined
+    let timeout = constants.DEFAULT_REQUEST_TIMEOUT
+    let hostname = os.hostname()
+    let mac = undefined
+    let ip = undefined
+
+    if (has(options, 'level')) {
+      const level = options.level.toUpperCase()
+      if (!constants.LOG_LEVELS.includes(level)) {
+        const err = new Error('Invalid level')
+        err.meta = {
+          got: level
+        , expectedOneOf: constants.LOG_LEVELS
+        }
+        throw err
+      }
+      this.level = level
+    }
+
+    if (has(options, 'tags')) {
+      tags = options.tags
+      if (typeof tags === 'string') {
+        tags = tags.split(constants.TAGS_RE)
+      }
+      if (!Array.isArray(tags)) {
+        const err = new TypeError('tags should be passed as a String or an Array')
+        err.meta = {got: options.tags}
+        throw err
+      }
+      tags = tags
+        .filter((tag) => { return tag !== '' })
+        .map((tag) => { return tag.trim() })
+        .join(',')
+    }
+
+    if (has(options, 'meta')) {
+      const meta = options.meta
+      if (typeOf(meta) !== 'object') {
+        const err = new TypeError('meta needs to be an object of key-value pairs')
+        err.meta = {got: meta}
+        throw err
+      }
+      this[kMeta] = {...meta}
+    }
+
+    if (has(options, 'timeout')) {
+      if (!Number.isInteger(options.timeout)) {
+        const err = new TypeError('timeout must be an Integer')
+        err.meta = {got: options.timeout}
+        throw err
+      }
+      if (options.timeout > constants.MAX_REQUEST_TIMEOUT) {
+        throw new Error(
+          `timeout cannot be longer than ${constants.MAX_REQUEST_TIMEOUT}`
+        )
+      }
+      timeout = options.timeout
+    }
+
+    if (has(options, 'hostname')) {
+      checkStringParam(options.hostname, 'Hostname')
+      if (!constants.HOSTNAME_CHECK.test(options.hostname)) {
+        throw new Error('Invalid hostname')
+      }
+      hostname = options.hostname
+    }
+
+    if (has(options, 'mac')) {
+      checkStringParam(options.mac, 'MAC Address')
+      if (!constants.MAC_ADDR_CHECK.test(options.mac)) {
+        throw new Error('Invalid MAC Address format')
+      }
+      mac = options.mac
+    }
+
+    if (has(options, 'ip')) {
+      checkStringParam(options.ip, 'IP Address')
+      if (!isIP(options.ip)) {
+        throw new Error('Invalid IP Address format')
+      }
+      ip = options.ip
+    }
+
+    if (has(options, 'logdna_url')) {
+      console.warn('[Deprecated] logdna_url is deprecated.  Please use url instead.')
+      options.url = options.logdna_url
+    }
+    if (has(options, 'url')) {
+      checkStringParam(options.url, 'url')
+      if (!constants.PROTOCOL_RE.test(options.url)) {
+        const err = new Error('Invalid URL protocol')
+        err.meta = {
+          expected: 'http:// or https://'
+        }
+        throw err
+      }
+      useHttps = options.url.startsWith('https://')
+      this.url = options.url
+    }
+
+    if (has(options, 'flushLimit')) {
+      if (!Number.isInteger(options.flushLimit)) {
+        const err = new TypeError('flushLimit must be an integer')
+        err.meta = {got: options.flushLimit}
+        throw err
+      }
+      this.flushLimit = options.flushLimit
+    }
+
+    if (has(options, 'flushIntervalMs')) {
+      if (!Number.isInteger(options.flushIntervalMs)) {
+        const err = new TypeError('flushIntervalMs must be an integer')
+        err.meta = {got: options.flushIntervalMs}
+        throw err
+      }
+      this.flushIntervalMs = options.flushIntervalMs
+    }
+
+    if (has(options, 'baseBackoffMs')) {
+      if (!Number.isInteger(options.baseBackoffMs)
+        || options.baseBackoffMs <= 0) {
+
+        const err = new RangeError('baseBackoffMs must be an integer > 0')
+        err.meta = {got: options.baseBackoffMs}
+        throw err
+      }
+      this.baseBackoffMs = options.baseBackoffMs
+    }
+
+    if (has(options, 'maxBackoffMs')) {
+      if (!Number.isInteger(options.maxBackoffMs)
+        || options.maxBackoffMs <= 0
+        || options.maxBackoffMs < this.baseBackoffMs) {
+
+        const err = new RangeError(
+          'maxBackoffMs must be an integer > 0 and > baseBackoffMs'
+        )
+        err.meta = {
+          got: options.maxBackoffMs
+        , baseBackoffMs: this.baseBackoffMs
+        }
+        throw err
+      }
+      this.maxBackoffMs = options.maxBackoffMs
+    }
+
+    if (has(options, 'shimProperties')) {
+      const val = options.shimProperties
+      if (!Array.isArray(val) || !val.length) {
+        const err = new TypeError('shimProperties must be a non-empty array')
+        err.meta = {got: val}
+        throw err
+      }
+      this.shimProperties = val
+    }
+
+    if (has(options, 'max_length')) {
+      const err = new Error('Removed.  max_length is no longer an option.')
+      throw err
+    }
+
+    if (has(options, 'index_meta')) {
+      console.warn(
+        '[Deprecated] index_meta is deprecated.  Please use indexMeta.'
+      )
+      options.indexMeta = options.index_meta
+    }
+    if (has(options, 'indexMeta')) {
+      this.indexMeta = Boolean(options.indexMeta)
+    }
+
+    if (has(options, 'app')) {
+      checkStringParam(options.app, 'app')
+      this.app = options.app
+    }
+
+    if (has(options, 'env')) {
+      checkStringParam(options.env, 'env')
+      this.env = options.env
+    }
+
+    if (has(options, 'with_credentials')) {
+      console.warn(
+        '[Deprecated] with_credentials is deprecated.  Please use withCredentials.'
+      )
+      options.withCredentials = options.with_credentials
+    }
+    if (has(options, 'withCredentials')) {
+      withCredentials = Boolean(options.withCredentials)
+    }
+
+    let transportedBy = ''
+    if (has(options, 'UserAgent')) {
+      // Then the caller is a transport helper like Bunyan or Winston
+      // @see https://github.com/logdna/logdna-bunyan
+      // @see https://github.com/logdna/logdna-winston
+      transportedBy = ` (${options.UserAgent})`
+    }
+
+    this[kRequestDefaults] = {
+      auth: {username: key}
+    , agent: useHttps
+        ? new Agent.HttpsAgent(constants.AGENT_SETTING)
+        : new Agent(constants.AGENT_SETTING)
+    , headers: {
+        ...constants.DEFAULT_REQUEST_HEADER
+      , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
+      , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
+      }
+    , qs: {
+        hostname
+      , mac
+      , ip
+      , tags
+      }
+    , timeout
+    , withCredentials
+    , useHttps
+    }
+  }
+
+  addMetaProperty(key, value) {
+    this[kMeta] = {
+      ...this[kMeta]
+    , [key]: value
+    }
+    this.emit('addMetaProperty', {
+      message: META_ADD_SUCCESS
+    , key
+    , value
+    })
+  }
+
+  bufferLog(payload) {
+    const lineLength = payload.line.length
+
+    this[kLineLengthTotal] += lineLength
+    this[kBuffer].push(payload)
+
+    if (!this[kIsLoggingBackedOff] && (this[kLineLengthTotal] >= this.flushLimit)) {
+      // Buffer size meets (or exceeds) flush limit.  Immediately flushing
+      this.flush()
+      return
+    }
+
+    if (!this[kFlusher]) {
+      this[kFlusher] = setTimeout(this.flush.bind(this), this.flushIntervalMs)
+    }
+  }
+
+  flush() {
+    // Roll the current buffer into readyToSend and begin a new buffer
+    clearTimeout(this[kFlusher])
+    this[kFlusher] = null
+
+    const bufferLength = this[kBuffer].length
+    if (bufferLength) {
+      this[kReadyToSend].push(this[kBuffer])
+      this[kBuffer] = []
+      this[kLineLengthTotal] = 0
+      this[kTotalLinesReady] += bufferLength
+    }
+
+    if (this[kReadyToSend].length) {
+      this.send()
+      return
+    }
+
+    // setImmediate allows us to flush THEN await the event in code
+    setImmediate(this.emit.bind(this), 'cleared', {
+      message: ALL_CLEAR_EMPTY
+    })
+  }
+
+  log(statement, opts) {
+    opts = opts || {}
+
+    if (statement === null
+      || statement === undefined
+      || typeof statement === 'string' && !statement.length) {
+
+      this.emit('warn', {
+        message: WARN_LOG_IGNORED
+      , statement
+      })
+      return
+    }
+
+    const message = {
+      timestamp: Date.now()
+    , line: undefined
+    , level: this.level
+    , app: this.app
+    , env: this.env
+    , meta: undefined
+    }
+
+    if (typeof opts === 'string') {
+      // Then it should be a log level string
+      const level = opts.toUpperCase()
+      if (!constants.LOG_LEVELS.includes(level)) {
+        const err = new TypeError(
+          'If \'options\' is a string, then it must be a valid log level'
+        )
+        err.meta = {
+          got: opts
+        , expected: constants.LOG_LEVELS
+        }
+        this.emit('error', err)
+        return
+      }
+      message.level = level
+      opts = {}
+    }
+    const optsType = typeOf(opts)
+    if (optsType !== 'object') {
+      const err = new TypeError(
+        'options parameter must be a level (string), or object'
+      )
+      err.meta = {
+        got: optsType
+      }
+      this.emit('error', err)
+      return
+    }
+
+    message.line = typeof statement === 'string'
+      ? statement
+      : stringify(statement)
+
+    if (has(opts, 'level')) {
+      // They've passed in a `level`.  Validate it.
+      const level = opts.level.toUpperCase()
+      if (constants.LOG_LEVELS.includes(level)) {
+        message.level = level
+      } else {
+        const err = new Error('Invalid log level.  Using the default instead.')
+        err.meta = {
+          got: level
+        , expected: constants.LOG_LEVELS
+        , used: message.level
+        }
+        this.emit('error', err)
+      }
+    }
+
+    message.app = opts.app || message.app
+    message.env = opts.env || message.env
+
+    if (opts.timestamp && isValidTimestamp(opts.timestamp)) {
+      message.timestamp = opts.timestamp
+    }
+
+    let meta = opts.meta || {}
+    if (opts.context && !opts.meta && typeOf(opts.context) === 'object') {
+      meta = opts.context
+    }
+
+    meta = {...this[kMeta], ...meta}
+    // Each message's options can override this.indexMeta
+    const indexMeta = has(opts, 'indexMeta')
+      ? opts.indexMeta
+      : this.indexMeta
+
+    if (indexMeta) {
+      message.meta = meta
+    } else {
+      message.meta = stringify(meta)
+    }
+
+    if (opts.logSourceCRN) {
+      message.logSourceCRN = opts.logSourceCRN
+    }
+
+    if (opts.saveServiceCopy) {
+      message.saveServiceCopy = opts.saveServiceCopy
+    }
+
+    if (opts.appOverride) {
+      message.appOverride = opts.appOverride
+    }
+
+    let withShims = null
+    if (this.shimProperties) {
+      const shimVals = {}
+      for (const prop of this.shimProperties) {
+        if (has(opts, prop)) {
+          shimVals[prop] = opts[prop]
+        }
+      }
+      withShims = {
+        ...message
+      , ...shimVals
+      }
+    }
+
+    const payload = withShims || message
+    this.bufferLog(payload)
+  }
+
+  removeMetaProperty(key) {
+    if (!has(this[kMeta], key)) {
+      this.emit('warn', {
+        message: REMOVE_META_WARN
+      , key
+      })
+      return
+    }
+    const rebuilt = {}
+    for (const [k, v] of Object.entries(this[kMeta])) {
+      if (k === key) continue
+      rebuilt[k] = v
+    }
+    this[kMeta] = rebuilt
+
+    this.emit('removeMetaProperty', {
+      message: REMOVE_META_SUCCESS
+    , key
+    })
+  }
+
+  send(calledByFlush = true) {
+    if (this[kIsSending] && calledByFlush) return
+    this[kIsSending] = true
+
+    const buffer = this[kReadyToSend][0]
+    const qs = {
+      now: Date.now()
+    , ...this[kRequestDefaults].qs
+    }
+
+    const config = {
+      method: 'post'
+    , url: this.url + '?' + querystring.stringify(qs)
+    , headers: this[kRequestDefaults].headers
+    , data: stringify({e: 'ls', ls: buffer})
+    , timeout: this[kRequestDefaults].timeout
+    , withCredentials: this[kRequestDefaults].withCredentials
+    , json: true
+    , httpsAgent: undefined
+    , httpAgent: undefined
+    }
+
+    const agentKey = this[kRequestDefaults].useHttps
+      ? 'httpsAgent'
+      : 'httpAgent'
+    config[agentKey] = this[kRequestDefaults].agent
+
+    const firstLine = buffer[0].line
+    const lastLine = buffer.length > 1
+      ? buffer[buffer.length - 1].line
+      : null
+
+    axios(config)
+      .then((response) => {
+        // We have a 200-level success code.
+        const totalLinesSent = buffer.length
+        this[kIsLoggingBackedOff] = false
+        this[kAttempts] = 0
+        this[kIsSending] = false
+        this[kTotalLinesReady] -= totalLinesSent
+        this[kReadyToSend].shift()
+
+        // Assist GC by killing the buffer and removing it from readyToSend
+        buffer.length = 0
+
+        this.emit('send', {
+          httpStatus: response.status
+        , firstLine
+        , lastLine
+        , totalLinesSent
+        , totalLinesReady: this[kTotalLinesReady]
+        , bufferCount: this[kReadyToSend].length
+        })
+
+        if (this[kReadyToSend].length) {
+          // Continue to send any backed up payloads that have accumulated
+          this.send()
+          return
+        }
+
+        this.emit('cleared', {
+          message: ALL_CLEAR_SENT
+        })
+      })
+      .catch((error) => {
+        const code = error.response
+          ? error.response.status
+          : error.code // timeouts will populate this
+
+        const retrying = ERROR_CODES_TO_RETRY.has(code)
+        const err = new Error('An error occured while sending logs to the cloud.')
+        err.meta = {
+          actual: error.message
+        , code
+        , firstLine
+        , lastLine
+        , retrying
+        , attempts: ++this[kAttempts]
+        }
+        this.emit('error', err)
+
+        if (retrying) {
+          this[kIsLoggingBackedOff] = true
+          this[kBackoffMs] = backoffWithJitter(
+            this.baseBackoffMs
+          , this.maxBackoffMs
+          , this[kBackoffMs]
+          )
+          setTimeout(() => {
+            this.send(false)
+          }, this[kBackoffMs])
+          return
+        }
+
+        // User-level errors will be discarded since they will never succeed
+        this[kIsSending] = false
+        this[kTotalLinesReady] -= buffer.length
+        this[kAttempts] = 0
+        this[kReadyToSend].shift()
+        buffer.length = 0
+        if (this[kReadyToSend].length) {
+          this.send()
+          return
+        }
+
+        this.emit('cleared', {
+          message: ALL_CLEAR_SENT
+        })
+      })
+  }
+}
+
+// Make documented methods enumerable as a courtesy
+Object.defineProperties(Logger.prototype, {
+  addMetaProperty: {
+    enumerable: true
+  }
+, flush: {
+    enumerable: true
+  }
+, log: {
+    enumerable: true
+  }
+, removeMetaProperty: {
+    enumerable: true
+  }
+})
+
+/*
+ *  Populate short-hand for each supported Log Level
+ */
+for (const level of constants.LOG_LEVELS) {
+  const levelLowerCase = level.toLowerCase()
+
+  Object.defineProperties(Logger.prototype, {
+    [levelLowerCase]: {
+      enumerable: true
+    , writable: false
+    , configurable: false
+    , value(statement, opts) {
+        const optsType = typeOf(opts)
+        if (opts && optsType !== 'object') {
+          const err = new TypeError(
+            `If passed, log.${levelLowerCase} requires 'options' to be an object`
+          )
+          err.meta = {
+            got: optsType
+          }
+          throw err
+        }
+        const options = {
+          ...opts
+        , level
+        }
+        this.log(statement, options)
+      }
+    }
+  })
+}
+
+module.exports = Logger

--- a/lib/validators/check-string-param.js
+++ b/lib/validators/check-string-param.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const constants = require('../constants.js')
+
+module.exports = function checkStringParam(param, name) {
+  if (!param || typeof param !== 'string') {
+    throw new TypeError(`${name} is undefined or not passed as a String`)
+  }
+  if (param.length > constants.MAX_INPUT_LENGTH) {
+    throw new TypeError(
+      `${name} cannot be longer than ${constants.MAX_INPUT_LENGTH} chars`
+    )
+  }
+}

--- a/lib/validators/has.js
+++ b/lib/validators/has.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// Checks for a property's existence in an object.  If `mustHaveValue`
+// is true, then has() will also expect that the value is not null or undefined.
+
+module.exports = function has(obj, prop) {
+  const exists = Object.prototype.hasOwnProperty.call(obj, prop)
+  if (!exists) return false
+  if (obj[prop] === undefined || obj[prop] === null) return false
+
+  return true
+}

--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  checkStringParam: require('./check-string-param.js')
+, has: require('./has.js')
+, isValidTimestamp: require('./is-valid-timestamp.js')
+}

--- a/lib/validators/is-valid-timestamp.js
+++ b/lib/validators/is-valid-timestamp.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const constants = require('../constants.js')
+
+module.exports = function isValidTimestamp(timestamp) {
+  const date = new Date(timestamp)
+  if (isNaN(date) || Math.abs(timestamp - Date.now()) > constants.MS_IN_A_DAY) {
+    return false
+  }
+  return true
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@logdna/logger",
+  "version": "1.0.0",
+  "description": "LogDNA's Node.js Logging Module.",
+  "main": "index.js",
+  "types": "types.d.ts",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "pretest": "npm run lint",
+    "test": "tap"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/logdna/logger-node.git"
+  },
+  "keywords": [
+    "logdna",
+    "logs",
+    "logging",
+    "winston",
+    "bunyan",
+    "nodejs",
+    "node",
+    "logdna.com",
+    "logger",
+    "javascript"
+  ],
+  "author": {
+    "name": "LogDNA, Inc.",
+    "email": "help@logdna.com"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/logdna/logger-node/issues"
+  },
+  "homepage": "https://github.com/logdna/logger-node#readme",
+  "peerDependencies": {
+    "eslint": ">= 6"
+  },
+  "eslintConfig": {
+    "root": true,
+    "ignorePatterns": [
+      "node_modules/",
+      "coverage/"
+    ],
+    "parserOptions": {
+      "ecmaVersion": 2019
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "axios": "^0.19.0",
+    "json-stringify-safe": "^5.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^7.4.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-sensible": "^2.2.0",
+    "nock": "^13.0.2",
+    "tap": "^14.10.8"
+  }
+}

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -1,0 +1,46 @@
+'use strict'
+
+module.exports = function createOptions({
+  key = '< YOUR INGESTION KEY HERE >'
+, hostname = 'AWESOMEHOSTER'
+, ip = '10.0.1.101'
+, mac = 'C0:FF:EE:C0:FF:EE'
+, app = 'testing.log'
+, test = true
+, port = 1337
+, flushIntervalMs = 1 // Immediate flushing should be the default
+, flushLimit = null
+, indexMeta = null
+, level = undefined
+, tags = null
+, timeout = null
+, shimProperties
+, env = undefined
+, withCredentials = null
+, url = `http://localhost:${port}`
+, baseBackoffMs = undefined
+, maxBackoffMs = undefined
+, meta = undefined
+} = {}) {
+  return {
+    key
+  , hostname
+  , ip
+  , mac
+  , app
+  , test
+  , url
+  , flushIntervalMs
+  , flushLimit
+  , indexMeta
+  , level
+  , tags
+  , timeout
+  , shimProperties
+  , env
+  , withCredentials
+  , baseBackoffMs
+  , maxBackoffMs
+  , meta
+  }
+}

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  apiKey: '< YOUR INGESTION KEY HERE >'
+, createOptions: require('./create-options.js')
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const {test} = require('tap')
+const index = require('../index.js')
+const {apiKey, createOptions} = require('./common/index.js')
+
+test('Index exports are correct', async (t) => {
+  t.equal(Object.keys(index).length, 2, 'property count is correct')
+  t.match(index, {
+    createLogger: Function
+  , setupDefaultLogger: Function
+  }, 'Exported properties are correct')
+})
+
+test('setupDefaultLogger', async (t) => {
+  t.test('Create the singleton', async (tt) => {
+    const instance = index.setupDefaultLogger(
+      apiKey
+    , createOptions({
+        app: 'MyDefaultApp'
+      })
+    )
+    tt.equal(instance.constructor.name, 'Logger', 'Returned an instance')
+    tt.equal(instance.app, 'MyDefaultApp', 'App name is correct')
+  })
+
+  t.test('Singleton is returned', async (tt) => {
+    const instance = index.setupDefaultLogger(
+      apiKey
+    , createOptions({
+        app: 'ThisWillNotWork'
+      })
+    )
+    tt.equal(instance.constructor.name, 'Logger', 'Returned an instance')
+    tt.equal(instance.app, 'MyDefaultApp', 'App name is correct')
+  })
+})
+
+test('createLogger instantiates a Logger instance correctly', async (t) => {
+  const log = index.createLogger(apiKey, createOptions())
+  t.equal(log.constructor.name, 'Logger', 'instance returned')
+})

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const http = require('http')
+const {test} = require('tap')
+const {createLogger} = require('../index.js')
+
+const TOTAL_LINES = 100000
+let httpCalls = 0
+let linesReceived = 0
+let sendEvents = 0
+let errorEvents = 0
+
+const server = http.createServer((req, res) => {
+  let buffer = ''
+  req.on('data', (data) => {
+    buffer += data
+  })
+  req.on('end', () => {
+    const body = JSON.parse(buffer)
+    if (++httpCalls % 2 === 0) {
+      res.statusCode = 500
+      res.end('POOF - The request should be retried')
+      return
+    }
+    linesReceived += body.ls.length
+    res.statusCode = 200
+    res.end('Ingested')
+  })
+})
+
+test('Load test to ensure no data loss and expected payloads', async (t) => {
+  const line = 'x'.repeat(500)
+
+  t.test('Start a local HTTP server', (tt) => {
+    server.listen(0)
+    server.on('listening', tt.end)
+  })
+
+  t.test(`Test ${TOTAL_LINES} lines`, (tt) => {
+    const logger = createLogger('<YOUR KEY HERE>', {
+      retryTimes: 100
+    , baseBackoffMs: 100
+    , maxBackoffMs: 500
+    , url: `http://localhost:${server.address().port}`
+    })
+
+    logger.on('send', (evt) => {
+      sendEvents++
+      tt.match(evt, {
+        httpStatus: 200
+      , firstLine: line
+      , lastLine: line
+      , totalLinesSent: Number
+      , totalLinesReady: Number
+      , bufferCount: Number
+      }, 'send event payload is correct')
+    })
+
+    logger.on('error', (evt) => {
+      errorEvents++
+      tt.deepEqual(evt, {
+        name: 'Error'
+      , message: 'An error occured while sending logs to the cloud.'
+      , meta: {
+          actual: 'Request failed with status code 500'
+        , code: 500
+        , firstLine: line
+        , lastLine: line
+        , retrying: true
+        , attempts: 1 // We will not fail twice in a row in this test
+        }
+      }, 'Error event is correct', evt)
+    })
+
+    logger.on('cleared', () => {
+      tt.pass('\'cleared\' event received!')
+      // Based on the payload size, and the given instantiation options for
+      // buffer size, etc, we can know how many HTTP calls and events we
+      // can expect to have happened.
+      tt.equal(linesReceived, TOTAL_LINES, 'Lines sent equals lines received')
+      tt.equal(httpCalls, 19, 'HTTP call count (including errors) is correct')
+      tt.equal(sendEvents, 10, '\'send\' event count does not include errors')
+      tt.equal(errorEvents, 9, 'Expected error count')
+      logger.removeAllListeners()
+      server.close(() => {
+        tt.end()
+      })
+    })
+
+    for (let i = 0; i < TOTAL_LINES; i++) {
+      logger.info(line)
+    }
+  })
+})

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -1,0 +1,408 @@
+'use strict'
+
+const {test} = require('tap')
+const nock = require('nock')
+const Logger = require('../lib/logger.js')
+const constants = require('../lib/constants.js')
+const {apiKey, createOptions} = require('./common/index.js')
+
+nock.disableNetConnect()
+
+test('Shorthand logging calls require options to be an object', (t) => {
+  t.plan(constants.LOG_LEVELS.length)
+  const logger = new Logger(apiKey)
+
+  for (const level of constants.LOG_LEVELS) {
+    const levelLowerCase = level.toLowerCase()
+    const expected = `If passed, log.${levelLowerCase} requires 'options' `
+      + 'to be an object'
+    t.throws(() => {
+      logger[levelLowerCase]('Log line', 'NOPE')
+    }, {
+      message: expected
+    , meta: {got: 'string'}
+    , name: 'TypeError'
+    }, `log.${levelLowerCase} throws as expected`)
+  }
+})
+
+test('timestamp validity checks', (t) => {
+  t.plan(4)
+  const startTime = Date.now()
+  const logger = new Logger(apiKey, createOptions({
+    flushIntervalMs: 10
+  }))
+
+  logger.on('warn', t.fail)
+  logger.on('error', t.fail)
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls
+      t.equal(payload.length, 2, 'Number of lines is correct')
+      const [{timestamp: stamp1}, {timestamp: stamp2}] = payload
+      t.ok(stamp1 > startTime, 'bad time format was replaced with a good one')
+      t.ok(stamp2 > startTime, 'out of range time was replaced with a good one')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+    .persist()
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'my log line'
+    , lastLine: 'my log line'
+    , totalLinesSent: 2
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.info('my log line', {
+    timestamp: {}
+  })
+  logger.info('my log line', {
+    timestamp: startTime + constants.MS_IN_A_DAY
+  })
+})
+
+test('.log() throws if options is a string and not a valid log entry', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions())
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('error', (err) => {
+    t.type(err, TypeError, 'Expected to be a TypeError')
+    t.deepEqual(err, {
+      name: 'TypeError'
+    , message: 'If \'options\' is a string, then it must be a valid log level'
+    , meta: {
+        got: 'NOPE'
+      , expected: constants.LOG_LEVELS
+      }
+    }, 'Expected Error is correct')
+  })
+  logger.log('log line', 'NOPE')
+})
+
+test('.log() rejects invalid `opts` data type', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions())
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('error', (err) => {
+    t.type(err, TypeError, 'Expected to be a TypeError')
+    t.match(err, {
+      name: 'TypeError'
+    , message: 'options parameter must be a level (string), or object'
+    , meta: {
+        got: 'number'
+      }
+    }, 'Expected Error is correct')
+  })
+  logger.log('log line', 12345)
+})
+
+test('.log() passed an invalid log level uses the default instead', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    level: 'info'
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const obj = body.ls[0]
+      t.equal(obj.level, 'INFO', 'Default level was used instead')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Expected to be an Error')
+    t.deepEqual(err, {
+      name: 'Error'
+    , message: 'Invalid log level.  Using the default instead.'
+    , meta: {
+        got: 'NEIGH'
+      , expected: constants.LOG_LEVELS
+      , used: logger.level
+      }
+    }, 'Expected Error is correct')
+  })
+  logger.log('log line', {level: 'NEIGH'})
+})
+
+test('.log() ignores empty or null messages', async (t) => {
+  const logger = new Logger(apiKey, createOptions())
+
+  t.test('Statement is null', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: null
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.log(null)
+  })
+
+  t.test('Statement is undefined', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: null
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.log(undefined)
+  })
+
+  t.test('Statement is an empty string', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: ''
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.log('')
+  })
+})
+
+test('removeMetaProperty emits \'warn\' if property is not found', (t) => {
+  t.plan(1)
+  const logger = new Logger(apiKey)
+
+  logger.on('removeMetaProperty', t.fail)
+  logger.on('warn', (obj) => {
+    t.deepEqual(obj, {
+      message: 'Property is not an existing meta property.  Cannot remove.'
+    , key: 'NOPE'
+    }, 'Got expected warning')
+  })
+  logger.removeMetaProperty('NOPE')
+})
+
+test('HTTP timeout will emit Error and continue to retry', (t) => {
+  const delay = 1000 // Set this low since nock will ultimately wait to timeout
+  const logger = new Logger(apiKey, createOptions({
+    baseBackoffMs: 100
+  , maxBackoffMs: 500
+  , timeout: delay
+  }))
+  let attempts = 0
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  // Fail 3 times, then succeed. FYI, the axios agent treats a timeout on connection
+  // the same as a timeout on response body (connection accepted; no reply)
+  nock(logger.url)
+    .post('/', () => {
+      t.equal(
+        logger[Symbol.for('isLoggingBackedOff')]
+      , false
+      , 'Logger is not backed off prior to the first failure'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .delayConnection(delay + 1)
+    .reply(200, 'Will Not Happen')
+    .post('/', () => {
+      t.equal(
+        logger[Symbol.for('isLoggingBackedOff')]
+      , true
+      , 'Logger is backed off'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .delayConnection(delay + 1)
+    .reply(200, 'Will Not Happen')
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .delayConnection(delay + 1)
+    .reply(200, 'Will Not Happen')
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Success')
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Error type is emitted')
+    t.deepEqual(err, {
+      message: 'An error occured while sending logs to the cloud.'
+    , name: 'Error'
+    , meta: {
+        actual: `timeout of ${delay}ms exceeded`
+      , code: 'ECONNABORTED'
+      , firstLine: 'This will cause an HTTP timeout'
+      , lastLine: null
+      , retrying: true
+      , attempts: ++attempts
+      }
+    }, `Error properties are correct for attempt ${attempts}`)
+  })
+
+  logger.on('cleared', ({message}) => {
+    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.equal(
+      logger[Symbol.for('isLoggingBackedOff')]
+    , false
+    , 'Logger is not backed off after having a successful connection'
+    )
+    t.end()
+  })
+
+  logger.log('This will cause an HTTP timeout')
+})
+
+test('A 500-error will continue to retry', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    baseBackoffMs: 100
+  , maxBackoffMs: 500
+  }))
+  let attempts = 0
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  // Fail 3 times, then succeed
+  nock(logger.url)
+    .post('/', () => {
+      t.equal(
+        logger[Symbol.for('isLoggingBackedOff')]
+      , false
+      , 'Logger is not backed off prior to the first failure'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(500, 'SERVER KABOOM')
+    .post('/', () => {
+      t.equal(
+        logger[Symbol.for('isLoggingBackedOff')]
+      , true
+      , 'Logger is backed off'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(500, 'SERVER KABOOM')
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(500, 'SERVER KABOOM')
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Success')
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Error type is emitted')
+    t.match(err, {
+      message: 'An error occured while sending logs to the cloud.'
+    , meta: {
+        actual: 'Request failed with status code 500'
+      , code: 500
+      , firstLine: 'This will cause an HTTP timeout'
+      , lastLine: null
+      , retrying: true
+      , attempts: ++attempts
+      }
+    }, `Error properties are correct for attempt ${attempts}`)
+  })
+
+  logger.on('cleared', ({message}) => {
+    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.equal(
+      logger[Symbol.for('isLoggingBackedOff')]
+    , false
+    , 'Logger is not backed off after having a successful connection'
+    )
+    t.end()
+  })
+
+  logger.log('This will cause an HTTP timeout')
+})
+
+test('User-level errors are discarded after emitting an error', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    flushLimit: 10 // one message per buffer
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', () => {
+      t.equal(
+        logger[Symbol.for('isLoggingBackedOff')]
+      , false
+      , 'User errors did not cause logger to back off'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(400, {
+      error: 'Nope, your line was invlalid somehow'
+    })
+    .persist()
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Error type is emitted')
+    t.match(err, {
+      message: 'An error occured while sending logs to the cloud.'
+    , meta: {
+        actual: 'Request failed with status code 400'
+      , code: 400
+      , firstLine: /^Something/
+      , lastLine: null
+      , retrying: false
+      , attempts: 1
+      }
+    }, 'Error properties are correct for a user error')
+  })
+
+  logger.on('cleared', ({message}) => {
+    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.equal(logger[Symbol.for('isSending')], false, 'no longer sending')
+    t.equal(logger[Symbol.for('totalLinesReady')], 0, 'no more lines ready')
+    t.deepEqual(logger[Symbol.for('readyToSend')], [], 'send buffer is empty')
+    t.end()
+  })
+
+  logger.log('Something is invalid about this line')
+  logger.log('Something else is wrong with this line too')
+})

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -1,0 +1,482 @@
+'use strict'
+
+const {test} = require('tap')
+const pkg = require('../package.json')
+const Logger = require('../lib/logger.js')
+const constants = require('../lib/constants.js')
+const {apiKey, createOptions} = require('./common/index.js')
+
+test('Exports structure', async (t) => {
+  t.type(Logger, Function, 'Logger is a function')
+  t.equal(Logger.name, 'Logger', 'Class name is correct')
+
+  const methods = Object.getOwnPropertyNames(Logger.prototype)
+  t.equal(methods.length, 13, 'Logger.prototype prop count')
+  t.deepEqual(methods, [
+    'constructor'
+  , 'addMetaProperty'
+  , 'bufferLog'
+  , 'flush'
+  , 'log'
+  , 'removeMetaProperty'
+  , 'send'
+  , 'trace'
+  , 'debug'
+  , 'info'
+  , 'warn'
+  , 'error'
+  , 'fatal'
+  ], 'Methods names as expected')
+})
+
+test('Logger instantiation', async (t) => {
+  const log = new Logger(apiKey, createOptions())
+  t.equal(log.constructor.name, 'Logger', 'instance returned')
+})
+
+test('Logger instance properties', async (t) => {
+  t.test('Check Symbol creation and defaults', async (tt) => {
+    const log = new Logger(apiKey)
+    const propertyVals = {}
+    for (const sym of Object.getOwnPropertySymbols(log)) {
+      propertyVals[sym.toString()] = log[sym]
+    }
+    const symbolCount = Object.keys(propertyVals).length
+    tt.equal(symbolCount, 11, 'The number of declared symbols')
+    const expected = {
+      'Symbol(lineLengthTotal)': 0
+    , 'Symbol(buffer)': []
+    , 'Symbol(meta)': {}
+    , 'Symbol(isLoggingBackedOff)': false
+    , 'Symbol(attempts)': 0
+    , 'Symbol(flusher)': null
+    , 'Symbol(readyToSend)': []
+    , 'Symbol(isSending)': false
+    , 'Symbol(totalLinesReady)': 0
+    , 'Symbol(backoffMs)': 3000
+    , 'Symbol(requestDefaults)': {
+        auth: {
+          username: apiKey
+        }
+      , agent: Object
+      , headers: {
+          'Content-Type': 'application/json; charset=UTF-8'
+        , 'user-agent': `${pkg.name}/${pkg.version}`
+        , 'Authorization': /^Basic \w+/
+        }
+      , qs: {
+          hostname: String
+        , mac: undefined
+        , ip: undefined
+        , tags: undefined
+        }
+      , timeout: 5000
+      , withCredentials: false
+      , useHttps: true
+      }
+    }
+    tt.equal(Object.keys(expected).length, symbolCount, 'Each symbol is tested')
+    tt.match(propertyVals, expected, 'Symbol property defaults are correct')
+  })
+
+  t.test('Check default property values', async (tt) => {
+    const log = new Logger(apiKey)
+    tt.match(log, {
+      flushLimit: 5000000
+    , flushIntervalMs: 250
+    , baseBackoffMs: 3000
+    , maxBackoffMs: 30000
+    , indexMeta: false
+    , url: 'https://logs.logdna.com/logs/ingest'
+    , app: 'default'
+    , level: 'INFO'
+    , [Symbol.for('requestDefaults')]: {
+        userHttps: true
+      }
+    })
+  })
+
+  t.test('Property Overrides with instantiation', async (tt) => {
+    const ipv6 = 'fe80::f475:68ff:fefa:42ec%awdl0'
+    const options = createOptions({
+      baseBackoffMs: 1000
+    , maxBackoffMs: 60000
+    , flushIntervalMs: 300
+    , flushLimit: 400
+    , indexMeta: true
+    , level: 'dEbUg'
+    , timeout: 5000
+    , shimProperties: ['one', 'two', 'three']
+    , env: 'myEnv'
+    , app: 'someAppName'
+    , withCredentials: true
+    , url: 'http://localhost:80'
+    , ip: ipv6
+    , meta: {hey: 'there'}
+    , hostname: 'bleck'
+    , mac: '01:02:03:04:05:06'
+    , tags: ['whiz', 'bang', 'done']
+    })
+    const log = new Logger(apiKey, options)
+
+    const expected = {
+      baseBackoffMs: options.baseBackoffMs
+    , maxBackoffMs: options.maxBackoffMs
+    , flushLimit: options.flushLimit
+    , flushIntervalMs: options.flushIntervalMs
+    , indexMeta: options.indexMeta
+    , level: 'DEBUG'
+    , shimProperties: options.shimProperties
+    , env: options.env
+    , app: options.app
+    , url: options.url
+    , [Symbol.for('requestDefaults')]: {
+        withCredentials: options.withCredentials
+      , useHttps: false
+      , qs: {
+          hostname: options.hostname
+        , mac: options.mac
+        , ip: ipv6
+        , tags: options.tags
+        }
+      , timeout: options.timeout
+      }
+    }
+
+    tt.match(log, expected, 'Provided values were used in instantiation')
+  })
+
+  t.test('UserAgent passed from a transport is included', async (tt) => {
+    const transport = 'logdna-winson/2.3.2'
+    const log = new Logger(apiKey, {
+      UserAgent: transport
+    })
+    tt.equal(
+      log[Symbol.for('requestDefaults')].headers['user-agent']
+    , `${constants.USER_AGENT} (${transport})`
+    , 'UserAgent parameter was combined into the user agent header'
+    )
+  })
+
+  t.test('Tags can be a string', async (tt) => {
+    const options = createOptions({
+      tags: 'one ,  two,   three  '
+    })
+    const expected = 'one,two,three'
+    const log = new Logger(apiKey, options)
+    tt.equal(
+      log[Symbol.for('requestDefaults')].qs.tags
+    , expected
+    , 'Tag string was parsed correctly and set'
+    )
+  })
+
+  t.test('Tags can be an array', async (tt) => {
+    const options = createOptions({
+      tags: ['one ', 'two  ', 'three   ']
+    })
+    const expected = 'one,two,three'
+    const log = new Logger(apiKey, options)
+    tt.equal(
+      log[Symbol.for('requestDefaults')].qs.tags
+    , expected
+    , 'Tags array was parsed correctly and set'
+    )
+  })
+})
+
+test('Deprecated fields are still allowed and re-assigned', async (t) => {
+  t.test('logdna_url is re-assigned to url', async (tt) => {
+    const log = new Logger(apiKey, {
+      logdna_url: 'http://myhost'
+    })
+    tt.equal(log.url, 'http://myhost', 'url was set instead')
+  })
+
+  t.test('index_meta is re-assigned to indexMeta', async (tt) => {
+    const log = new Logger(apiKey, {
+      index_meta: true
+    })
+    tt.equal(log.indexMeta, true, 'indexMeta was set instead')
+  })
+
+  t.test('with_credentails is re-assigned to withCredentials', async (tt) => {
+    const log = new Logger(apiKey, {
+      with_credentials: true
+    })
+    tt.equal(
+      log[Symbol.for('requestDefaults')].withCredentials
+    , true
+    , 'withCredentials was set instead'
+    )
+  })
+})
+
+test('Instantiation Errors', async (t) => {
+  t.test('Auth key is required', async (tt) => {
+    tt.throws(() => {
+      return new Logger()
+    }, {
+      message: 'LogDNA Ingestion Key is undefined or not passed as a String'
+    , name: 'TypeError'
+    }, 'Expected error thrown')
+  })
+
+  t.test('Level is a bad value', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        level: 'NOPE'
+      })
+    }, {
+      message: 'Invalid level'
+    , meta: {
+        got: 'NOPE'
+      , expectedOneOf: constants.LOG_LEVELS
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('Tags is not a string or an array', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        tags: {}
+      })
+    }, {
+      message: 'tags should be passed as a String or an Array'
+    , name: 'TypeError'
+    , meta: {got: {}}
+    }, 'Expected error thrown')
+  })
+
+  t.test('Meta is not an object', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        meta: 'NOPE'
+      })
+    }, {
+      message: 'meta needs to be an object of key-value pairs'
+    , name: 'TypeError'
+    , meta: {got: 'NOPE'}
+    }, 'Expected error thrown')
+  })
+
+  t.test('Timeout is not a number', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        timeout: 'NOPE'
+      })
+    }, {
+      message: 'timeout must be an Integer'
+    , name: 'TypeError'
+    , meta: {got: 'NOPE'}
+    }, 'Expected error thrown')
+  })
+
+  t.test('Timeout is greater than the allowable value', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        timeout: constants.MAX_REQUEST_TIMEOUT + 1
+      })
+    }, {
+      message: `timeout cannot be longer than ${constants.MAX_REQUEST_TIMEOUT}`
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad hostname', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        hostname: 'ws://localhost'
+      })
+    }, {
+      message: 'Invalid hostname'
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad MAC address', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        mac: 'NOPE'
+      })
+    }, {
+      message: 'Invalid MAC Address format'
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad IP address', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        ip: 'NOPE'
+      })
+    }, {
+      message: 'Invalid IP Address format'
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad Server URL', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        url: 'NOPE'
+      })
+    }, {
+      message: 'Invalid URL'
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad flushLimit', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        flushLimit: 'NOPE'
+      })
+    }, {
+      message: 'flushLimit must be an integer'
+    , name: 'TypeError'
+    , meta: {
+        got: 'NOPE'
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad flushIntervalMs', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        flushIntervalMs: 'NOPE'
+      })
+    }, {
+      message: 'flushIntervalMs must be an integer'
+    , name: 'TypeError'
+    , meta: {
+        got: 'NOPE'
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad baseBackoffMs', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        baseBackoffMs: 'NOPE'
+      })
+    }, {
+      message: 'baseBackoffMs must be an integer > 0'
+    , name: 'RangeError'
+    , meta: {
+        got: 'NOPE'
+      }
+    }, 'Expected error thrown')
+
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        baseBackoffMs: -1
+      })
+    }, {
+      message: 'baseBackoffMs must be an integer > 0'
+    , name: 'RangeError'
+    , meta: {
+        got: -1
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad maxBackoffMs', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        maxBackoffMs: 'NOPE'
+      , baseBackoffMs: 500
+      })
+    }, {
+      message: 'maxBackoffMs must be an integer > 0 and > baseBackoffMs'
+    , name: 'RangeError'
+    , meta: {
+        got: 'NOPE'
+      , baseBackoffMs: 500
+      }
+    }, 'Expected error thrown')
+
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        maxBackoffMs: -1
+      , baseBackoffMs: 500
+      })
+    }, {
+      message: 'maxBackoffMs must be an integer > 0 and > baseBackoffMs'
+    , name: 'RangeError'
+    , meta: {
+        got: -1
+      , baseBackoffMs: 500
+      }
+    }, 'Expected error thrown')
+
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        maxBackoffMs: 50
+      , baseBackoffMs: 200
+      })
+    }, {
+      message: 'maxBackoffMs must be an integer > 0 and > baseBackoffMs'
+    , name: 'RangeError'
+    , meta: {
+        got: 50
+      , baseBackoffMs: 200
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('shimProperties must be a non-empty aray', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        shimProperties: 'NOPE'
+      })
+    }, {
+      message: 'shimProperties must be a non-empty array'
+    , name: 'TypeError'
+    , meta: {
+        got: 'NOPE'
+      }
+    }, 'Expected error thrown')
+
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        shimProperties: []
+      })
+    }, {
+      message: 'shimProperties must be a non-empty array'
+    , name: 'TypeError'
+    , meta: {
+        got: []
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('max_length has been removed', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        max_length: 100
+      })
+    }, {
+      message: 'Removed.  max_length is no longer an option.'
+    }, 'Expected error thrown')
+  })
+
+  t.test('app name is too long', async (tt) => {
+    const app = 'x'.repeat(constants.MAX_INPUT_LENGTH) + 1
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        app
+      })
+    }, {
+      message: 'app cannot be longer than 80 chars'
+    , name: 'TypeError'
+    }, 'Expected error thrown')
+  })
+
+  t.test('env name is too long', async (tt) => {
+    const env = 'x'.repeat(constants.MAX_INPUT_LENGTH) + 1
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        env
+      })
+    }, {
+      message: 'env cannot be longer than 80 chars'
+    , name: 'TypeError'
+    }, 'Expected error thrown')
+  })
+})

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -1,0 +1,921 @@
+'use strict'
+
+const {test} = require('tap')
+const stringify = require('json-stringify-safe')
+const nock = require('nock')
+const Logger = require('../lib/logger.js')
+const constants = require('../lib/constants.js')
+const {apiKey, createOptions} = require('./common/index.js')
+
+nock.disableNetConnect()
+
+test('Test all log levels, including send events', async (t) => {
+  const opts = createOptions({
+    app: 'myApp'
+  })
+  const logger = new Logger(apiKey, opts)
+  const logText = 'This is my log text'
+  const responseText = 'This is the ingester response'
+
+  for (const LEVEL of constants.LOG_LEVELS) {
+    const level = LEVEL.toLowerCase()
+
+    t.test(`Calling with log.${level}`, (tt) => {
+      tt.plan(7)
+      tt.on('end', async () => {
+        logger.removeAllListeners()
+        nock.cleanAll()
+      })
+
+      const scope = nock(opts.url)
+        .post('/', (body) => {
+          const numProps = Object.keys(body).length
+          tt.equal(numProps, 2, 'Number of request body properties')
+          tt.match(body, {
+            e: 'ls'
+          , ls: [
+              {
+                timestamp: Number
+              , line: logText
+              , level: LEVEL
+              , app: opts.app
+              , meta: '{}'
+              }
+            ]
+          })
+          tt.equal(body.ls.length, 1, 'log line count')
+          return true
+        })
+        .query((qs) => {
+          tt.match(qs, {
+            hostname: opts.hostname
+          , mac: opts.mac
+          , ip: opts.ip
+          , tags: ''
+          , now: /^\d+$/
+          }, 'Querystring properties look correct')
+          return true
+        })
+        .reply(200, responseText)
+
+      logger.on('send', (obj) => {
+        tt.deepEqual(obj, {
+          httpStatus: 200
+        , firstLine: logText
+        , lastLine: null
+        , totalLinesSent: 1
+        , totalLinesReady: 0
+        , bufferCount: 0
+        }, 'Got send event')
+      })
+      logger.on('cleared', (obj) => {
+        tt.deepEqual(obj, {
+          message: 'All accumulated log entries have been sent'
+        }, 'Got cleared event')
+        tt.ok(scope.isDone(), 'Nock intercepted the http call')
+      })
+      logger[level](logText)
+    })
+  }
+})
+
+test('Using an https:// url sends and https agent', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    url: 'https://localhost:8888'
+  }))
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.line, 'This is over HTTPS', 'Log text was passed in body')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'This is over HTTPS'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log('This is over HTTPS')
+})
+
+test('log() can be called by itself without using a level shortcut', (t) => {
+  t.plan(4)
+  const logger = new Logger(apiKey, createOptions())
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.line, 'Hi there', 'Log text was passed in body')
+      t.equal(payload.level, 'INFO', 'Default level was used')
+      return true
+    })
+    .query((qs) => {
+      t.pass('Intercepted query string')
+      return true
+    })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hi there'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log('Hi there')
+})
+
+test('log() will work with falsey log lines, other than null/empty/undef', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    flushIntervalMs: 10 // Make SURE they're sent in the same batch
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const lines = body.ls.map((obj) => { return obj.line })
+      t.deepEqual(lines, ['0', 'false'], 'Request payload is correct')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+    .persist()
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: '0'
+    , lastLine: 'false'
+    , totalLinesSent: 2
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log(0)
+  logger.log(false)
+})
+
+test('log() can be passed an object to log, and serialization is "safe"', (t) => {
+  const logger = new Logger(apiKey, createOptions())
+  // json-stringify-safe allows circular refs
+  const circularObj = {key: 'val'}
+  circularObj.circularRef = circularObj
+  circularObj.list = [circularObj, circularObj]
+  const expected = stringify(circularObj)
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const line = body.ls[0].line
+      t.equal(line, expected, 'Object was serialized safely')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: expected
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    })
+  }, 'Got send event')
+  logger.info(circularObj)
+})
+
+test('log() can be called with level (case insensitive) as an opts string', (t) => {
+  const logger = new Logger(apiKey, createOptions())
+  const myLevel = 'DebuG'
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.level, 'DEBUG', 'Level is correct')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hi there'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    })
+  }, 'Got send event')
+  logger.log('Hi there', myLevel)
+})
+
+test('Call log() using an options object', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    app: 'MyApp'
+  }))
+  const myText = 'Hello there, I am logging'
+  const timestamp = Date.now()
+  const opts = {
+    timestamp
+  , level: 'trAcE'
+  , meta: {
+      myKey: 'myValue'
+    }
+  , logSourceCRN: 'some_logsource'
+  , saveServiceCopy: true
+  , appOverride: 'newApp'
+  , context: {}
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload, {
+        timestamp
+      , line: myText
+      , level: 'TRACE'
+      , app: 'MyApp'
+      , meta: JSON.stringify(opts.meta)
+      , logSourceCRN: 'some_logsource'
+      , saveServiceCopy: true
+      , appOverride: 'newApp'
+      }, 'Options were successfully placed into the message')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: myText
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log(myText, opts)
+})
+
+test('Using global meta in combination with per-message meta', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    meta: {
+      one: 1
+    , two: 2
+    , three: 3
+    }
+  }))
+  const opts = {
+    meta: {
+      two: 'TWO'
+    }
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      const expectedMeta = {
+        one: 1
+      , two: 'TWO'
+      , three: 3
+      }
+      t.equal(
+        payload.meta
+      , JSON.stringify(expectedMeta)
+      , 'per-message meta was merged with global meta'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hi'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.trace('Hi', opts)
+})
+
+test('Using opts.context will replace opts.meta', (t) => {
+  const logger = new Logger(apiKey, createOptions())
+  const opts = {
+    context: {
+      hello: 'there'
+    }
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.meta, JSON.stringify(opts.context), 'Context replaced meta')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hi'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.trace('Hi', opts)
+})
+
+test('opts.context is ignored when it\'s not an object', (t) => {
+  const logger = new Logger(apiKey, createOptions())
+  logger.addMetaProperty('inMeta', true)
+  const opts = {
+    context: 'NOPE'
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.meta, JSON.stringify({inMeta: true}), 'Context ignored')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hi'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.trace('Hi', opts)
+})
+
+test('Using opts.indexMeta will not stringify the meta data', (t) => {
+  const logger = new Logger(apiKey, createOptions())
+  const opts = {
+    indexMeta: true
+  , meta: {
+      luke: 'skywalker'
+    }
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload.meta, opts.meta, 'Meta is an object')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log('Howdy, folks!', opts)
+})
+
+test('indexMeta on at constructor keeps meta as an object', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: true
+  }))
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload.meta, {}, 'Meta is an object')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Hey there'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.log('Hey there', null)
+})
+
+test('Using _index_meta will not stringify the meta data', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: true
+  }))
+  const opts = {
+    meta: {
+      luke: 'skywalker'
+    }
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload.meta, opts.meta, 'Meta is an object')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.trace('Howdy, folks!', opts)
+})
+
+test('Shim properties are put into the meta', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    shimProperties: ['one', 'two', 'three', 'four']
+  , app: 'theBestApp'
+  }))
+  const timestamp = Date.now()
+  const opts = {
+    one: 1
+  , two: 2
+  , three: 3
+  , ignored: 'yes'
+  , timestamp
+  }
+
+  t.plan(2)
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload, {
+        timestamp
+      , line: 'Howdy, folks!'
+      , level: 'WARN'
+      , app: 'theBestApp'
+      , meta: '{}'
+      , one: 1
+      , two: 2
+      , three: 3
+      }, 'Message payload is correct')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+  logger.warn('Howdy, folks!', opts)
+})
+
+test('addMetaProperty() adds it to each message; indexMeta: true', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: true
+  }))
+
+  logger.on('addMetaProperty', (obj) => {
+    t.deepEqual(obj, {
+      message: 'Successfully added meta property'
+    , key: 'metaProp'
+    , value: 'metaVal'
+    }, 'Got addMetaProperty event')
+  })
+
+  logger.addMetaProperty('metaProp', 'metaVal')
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload.meta, {
+        metaProp: 'metaVal'
+      }, 'meta property injected into message payload')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.warn('Howdy, folks!')
+})
+
+test('addMetaProperty() adds it to each message; indexMeta: false', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: false
+  }))
+
+  logger.on('addMetaProperty', (obj) => {
+    t.deepEqual(obj, {
+      message: 'Successfully added meta property'
+    , key: 'metaProp'
+    , value: 'metaVal'
+    }, 'Got addMetaProperty event')
+  })
+
+  logger.addMetaProperty('metaProp', 'metaVal')
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(
+        payload.meta
+      , '{"metaProp":"metaVal"}'
+      , 'meta property injected into message payload'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.warn('Howdy, folks!')
+})
+
+test('removeMetaProperty() removes it from the payload; indexMeta: true', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: true
+  }))
+
+  logger.on('removeMetaProperty', (obj) => {
+    t.deepEqual(obj, {
+      message: 'Successfully removed meta property'
+    , key: 'two'
+    }, 'Got removeMetaProperty event')
+  })
+
+  logger.addMetaProperty('one', 1)
+  logger.addMetaProperty('two', 2)
+  logger.addMetaProperty('three', 3)
+  logger.removeMetaProperty('two')
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload.meta, {
+        one: 1
+      , three: 3
+      }, 'meta property was removed from the message payload')
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.warn('Howdy, folks!')
+})
+
+test('removeMetaProperty() removes it from the payload; indexMeta: false', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    indexMeta: false
+  }))
+
+  logger.on('removeMetaProperty', (obj) => {
+    t.deepEqual(obj, {
+      message: 'Successfully removed meta property'
+    , key: 'two'
+    }, 'Got removeMetaProperty event')
+  })
+
+  logger.addMetaProperty('one', 1)
+  logger.addMetaProperty('two', 2)
+  logger.addMetaProperty('three', 3)
+  logger.removeMetaProperty('two')
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.equal(payload.meta
+      , '{"one":1,"three":3}'
+      , 'meta property was removed from the message payload'
+      )
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Howdy, folks!'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.warn('Howdy, folks!')
+})
+
+test('Can call .log with HTTP (not https)', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    protocol: 'http'
+  }))
+  t.equal(logger[Symbol.for('requestDefaults')].useHttps, false, 'HTTPS is off')
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'This is not secure'
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.warn('This is not secure')
+})
+
+test('Flushing on a timer includes multiple lines', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions({
+    flushIntervalMs: 1000
+  }))
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls
+      t.equal(payload.length, 3, 'Payload has the right number of entries')
+      t.match(payload, [
+        {
+          timestamp: Number
+        , line: 'Line 1'
+        , level: 'INFO'
+        , app: logger.app
+        , meta: '{}'
+        }
+      , {
+          timestamp: Number
+        , line: 'Line 2'
+        , level: 'INFO'
+        , app: logger.app
+        , meta: '{}'
+        }
+      , {
+          timestamp: Number
+        , line: 'Line 3'
+        , level: 'INFO'
+        , app: logger.app
+        , meta: '{}'
+        }
+      ])
+      return true
+    })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: 'Line 1'
+    , lastLine: 'Line 3'
+    , totalLinesSent: 3
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.info('Line 1')
+  logger.info('Line 2')
+  logger.info('Line 3')
+})
+
+test('Immediately sends if byte size > flush byte limit', (t) => {
+  t.plan(5) // 3x 'send' + 'cleared'
+  let sendCount = 0
+  const then = Date.now()
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+  const logger = new Logger(apiKey, createOptions({
+    flushLimit: 10
+  , flushIntervalMs: 5000 // It should ignore this and flush immediately
+  }))
+
+  nock(logger.url)
+    .post('/', () => { return true })
+    .query(() => { return true })
+    .reply(200, 'Ingester response')
+    .persist()
+
+  const line = 'Hi, this is my line longer than 10 bytes'
+
+  logger.on('send', (obj) => {
+    const totalLinesSent = 1
+    let totalLinesReady
+    let bufferCount
+
+    switch (++sendCount) {
+      case 1:
+        totalLinesReady = 2
+        bufferCount = 2
+        break
+      case 2:
+        totalLinesReady = 1
+        bufferCount = 1
+        break
+      case 3:
+        totalLinesReady = 0
+        bufferCount = 0
+        break
+    }
+
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: null
+    , totalLinesSent
+    , totalLinesReady
+    , bufferCount
+    }, 'Expected send event received')
+  })
+
+  logger.on('cleared', (obj) => {
+    t.deepEqual(obj, {
+      message: 'All accumulated log entries have been sent'
+    }, 'Expected \'cleared\' event')
+    const now = Date.now()
+    t.ok(now - then < 5000, 'flush interval was ignored; Logs sent immediately')
+  })
+
+  logger.info(line)
+  logger.info(line)
+  logger.info(line)
+})
+
+test('flush() can be called any time, and always emits \'cleared\'', (t) => {
+  t.plan(3)
+  const logger = new Logger(apiKey, createOptions())
+
+  logger.on('cleared', ({message}) => {
+    t.equal(message, 'All buffers clear; Nothing to send', 'Got cleared event')
+  })
+
+  logger.flush()
+  logger.flush()
+  logger.flush()
+})

--- a/test/unit/lang/type-of.js
+++ b/test/unit/lang/type-of.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const {test, threw} = require('tap')
+const typeOf = require('../../../lib/lang/type-of.js')
+
+class FooBar {
+  get [Symbol.toStringTag]() {
+    return 'FooBar'
+  }
+}
+
+test('typeOf', (t) => {
+  t.type(typeOf, 'function', 'typeOf is a function')
+  const cases = [
+    {
+      value: ''
+    , expected: 'string'
+    }
+  , {
+      value: new Date()
+    , expected: 'date'
+    }
+  , {
+      value: null
+    , expected: 'null'
+    }
+  , {
+      value: undefined
+    , expected: 'undefined'
+    }
+  , {
+      value: 1.1
+    , expected: 'number'
+    }
+  , {
+      value: /\w+/
+    , expected: 'regexp'
+    }
+  , {
+      value: new FooBar()
+    , expected: 'foobar'
+    }
+  , {
+      value: new Set()
+    , expected: 'set'
+    }
+  , {
+      value: [1, 2]
+    , expected: 'array'
+    }
+  , {
+      value: {}
+    , expected: 'object'
+    }
+  , {
+      value: true
+    , expected: 'boolean'
+    }
+  , {
+      value: () => {}
+    , expected: 'function'
+    }
+  ]
+  for (const current of cases) {
+    t.equal(
+      typeOf(current.value)
+    , current.expected
+    , current.message || `typeOf(${current.value}) == ${current.expected}`
+    )
+  }
+  t.end()
+}).catch(threw)

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,63 @@
+declare module "logdna" {
+  enum LogLevel {
+    trace,
+    debug,
+    info,
+    warn,
+    error,
+    fatal
+  }
+
+  interface ConstructorOptions {
+    level?: LogLevel;
+    tags?: string | string[];
+    meta?: object;
+    timeout?: number;
+    hostname?: string;
+    mac?: string;
+    ip?: string;
+    url?: string;
+    flushLimit?: number;
+    flushIntervalMs?: number;
+    shimProperties?: string[];
+    indexMeta?: boolean;
+    app?: string;
+    env?: string;
+    baseBackoffMs?: number;
+    maxBackoffMs?: number;
+    withCredentials?: boolean;
+  }
+
+  interface LogOptions {
+    level?: LogLevel;
+    app?: string;
+    env?: string;
+    timestamp?: number;
+    context?: object;
+    indexMeta?: boolean;
+    meta?: object;
+  }
+
+  export interface Logger {
+    info(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    warn(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    debug(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    error(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    fatal(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    trace(statement: string | object, options?: Omit<LogOptions, 'level'>): void;
+    log(statement: string | object, options?: LogOptions): void;
+    addMetaProperty(key: string, value: any): void;
+    removeMetaProperty(key: string): void;
+    flush(): void;
+  }
+
+  export function createLogger(
+    key: string,
+    options?: ConstructorOptions
+  ): Logger;
+
+  export function setupDefaultLogger(
+    key: string,
+    options?: ConstructorOptions
+  ): Logger;
+}


### PR DESCRIPTION
This is a refactor of the last version from logdna/nodejs.  This version
uses a different npm namespace and repository, and fixes some usage
difficulties.

In general, callbacks do not work with a "flushing"
app due to the asynchronous nature of HTTP requests and dealing with
errors and retries.  Using an EventEmitter is much more appropriate,
so callbacks have been removed in this version as compared to
logdna/nodejs@3.5.1

CHANGE LIST:

* Removed `debug` since it's not compatible everywhere.  See
  issue (https://github.com/logdna/nodejs/issues/89)
* `class Logger` forces the use of the `new` keyword
* Helper functions are broken out to declutter the class file
* `configs.js` was renamed to the more appropriate `constants.js`
* Made all variables consistent in naming convention (lowerCamelCase)
* Added EventEmitter for successes, warnings and errors
* Fixed retry logic and possibility for double timers
* Fixed race condition with clearing a single buffer. Now, multiple
  buffers are used so that they can be independently cleared. This
  fixes a race condition where lines that were added during the HTTP
  request could be removed without being sent
* `log()` Options as a string must now be a log level. TypeError if not.
* Properly handles opts.meta, opts.context and this._meta
  according to `indexMeta`
* Removed `sizeof` since it was buggy.  Logic replaced with `.length`
  of the lines
* Added `meta` to the constructor so that it can easily be set without
  needing to call `addMetaProperty` after instantiation.
* Fixed map transitions; No dynamic addition of object properties or
  `delete` usage.
* `ip` can now be an IPv6 address
* Added a loadtest.js test to ensure there is not data loss
* Exponential Backoff with Jitter algorithm implemented for HTTP retries

Semver: major
Ref: LOG-6626