### PR TITLE
fix(docs): Fix broken Best Practices link in the migration document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes in the`LogDNA Node.js logger package`. The release numbering uses [semantic versioning](http://semver.org).
 
+## [1.0.1] - August 26, 2020
+### Fixed
+* Corrected a broken link ("Best Practices") in docs/migrating-from-older-versions.md
+
 ## [1.0.0] - August 25, 2020
 ### Changed
 * Removed `debug` since it's not compatible everywhere.  See
@@ -33,4 +37,5 @@ This file documents all notable changes in the`LogDNA Node.js logger package`. T
 * Added a loadtest.js test to ensure there is not data loss
 * Exponential Backoff with Jitter algorithm implemented for HTTP retries
 
+[1.0.1]: https://github.com/logdna/logger-node/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/logdna/logger-node/tree/1.0.0

--- a/docs/migrating-from-other-versions.md
+++ b/docs/migrating-from-other-versions.md
@@ -33,7 +33,7 @@ The following functions were removed
 * `cleanUpAll` - This is no longer necessary for the same reasons as `flushAll`
 
 If you were using these functions, then they are easily replaced by calling `flush` manually, and awaiting the `cleared`
-event as described in our [Best Practices](../README#best-practices) recommendations.
+event as described in our [Best Practices](../README.md#best-practices) recommendations.
 
 ## `options` Key Name Changes
 All keys for supported options are now lowerCamelCase for consistency.  Old names have been deprecated and will still


### PR DESCRIPTION
The file link was missing the `.md` extension.

Semver: patch