### PR TITLE
feat(agentLog): Add a logging method that can be called by the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@
     * [error](#event-error)
         * [Error while sending to LogDNA](#error-while-sending-to-logdna)
         * [Error while calling `log()`](#error-while-calling-log)
+        * [Error due to `payloadStructure` mismatch](#error-due-to-payloadstructure-mismatch)
     * [removeMetaProperty](#event-removeMetaProperty)
     * [send](#event-send)
     * [warn](#event-warn)
         * [Warnings during `log()`](#warnings-during-log)
+        * [Warnings during `agentLog()`](#warnings-during-agentlog)
         * [Warnings during `removeMetaProperty`](#warnings-during-removemetaproperty)
 * **[API](#api)**
     * [createLogger](#createloggerkey-options)
     * [setupDefaultLogger](#setupdefaultloggerkey-options)
+    * [logger.agentLog](#loggeragentlogopts)
     * [logger.addMetaProperty](#loggeraddmetapropertykey-value)
     * [logger.flush](#loggerflush)
     * [logger.log](#loggerlogstatement-options)
@@ -172,6 +175,14 @@ will contain the following properties:
 * `used` [`<String>`][] - If a bad `level` is used in `options`, it will be ignored, and the default will be used.
    This property indicates what that value is.
 
+#### Error due to `payloadStructure` mismatch
+
+When `log()` or `agentLog()` is called, the `payloadStructure` must be set appropriately.  If it is not, an error is emitted.
+Keep in mind that `agentLog()` is reserved for LogDNA systems and is not intended for public usage.
+
+* `message` [`<String>`][] - Static message of `Invalid method based on payloadStructure`
+* `payloadStructure` [`<String>`][] - The current payload structure value that is set on the instance
+* `expected` [`<String>`][] - The expected payload structure to be able to call the method.
 
 ### Event: `'removeMetaProperty'`
 
@@ -211,6 +222,10 @@ For those cases, additional properties (apart from `message`) are included:
 
 * `statement` (Any) - If `log()` was called with a `null` string or an invalid data type, this key will contain the given log statement.
 
+#### Warnings during `agentLog()`
+
+* `statement` (Any) - If `agentLog()` was called with a `null` string or an invalid data type, this key will contain the given log statement.
+
 #### Warnings during `removeMetaProperty`
 
 * `key` [`<String>`][] - The key that the command attempted to remove but that did not exist
@@ -238,6 +253,8 @@ For those cases, additional properties (apart from `message`) are included:
     * `baseBackoffMs` [`<Number>`][] - Minimum exponential backoff time in milliseconds. **Default:** `3000`ms
     * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
     * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
+    * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
+    * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
 * Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]
 * Returns: `Logger`
 
@@ -256,6 +273,9 @@ types, or the metadata object may not be parsed properly!
 `shimProperties` can be used to set up keys to look for in the `options` parameter of a `log()` call. If the specified keys
 are found in `options`, their key-values will be included the top-level of the final logging payload send to LogDNA.
 
+`payloadStructure` is only for LogDNA's use in other parts of the system such as our logging agent.
+It is not intended to be used by public consumers, and it should be left to the default value.
+
 For more information on the backoff algorithm and the options for it, see the [Exponential Backoff Strategy](#exponential-backoff-strategy) section.
 
 
@@ -272,6 +292,12 @@ const logdna = require('@logdna/logger')
 const logger = logdna.setupDefaultLogger('<YOUR KEY HERE>')
 const sameLogger = logdna.setupDefaultLogger()
 ```
+
+### `logger.agentLog(opts)`
+
+This method is for use exclusively by LogDNA, and is not intended for public logging.
+
+* Emits: [error](#event-error)
 
 ### `logger.addMetaProperty(key, value)`
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,10 @@ module.exports = {
 , MAX_LINE_LENGTH: 32000
 , MAX_REQUEST_TIMEOUT: 300000
 , MS_IN_A_DAY: 86400000
+, PAYLOAD_STRUCTURES: {
+    AGENT: 'agent'
+  , DEFAULT: 'default'
+  }
 , PROTOCOL_RE: /^https?:\/\//
 , REQUEST_WITH_CREDENTIALS: false
 , TAGS_RE: /\s*,\s*/

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events')
 const os = require('os')
 const querystring = require('querystring')
 const {isIP} = require('net')
+const zlib = require('zlib')
 const Agent = require('agentkeepalive')
 const axios = require('axios')
 const stringify = require('json-stringify-safe')
@@ -11,6 +12,7 @@ const constants = require('./constants.js')
 const {checkStringParam, isValidTimestamp, has} = require('./validators/index.js')
 const backoffWithJitter = require('./backoff-with-jitter.js')
 const typeOf = require('./lang/type-of.js')
+const payloads = require('./payloads.js')
 
 const kLineLengthTotal = Symbol('lineLengthTotal')
 const kBuffer = Symbol('buffer')
@@ -23,6 +25,8 @@ const kReadyToSend = Symbol.for('readyToSend')
 const kIsSending = Symbol.for('isSending')
 const kTotalLinesReady = Symbol.for('totalLinesReady')
 const kBackoffMs = Symbol('backoffMs')
+const kPayloadStructure = Symbol('payloadStructure')
+const kCompress = Symbol('compress')
 
 const ALL_CLEAR_SENT = 'All accumulated log entries have been sent'
 const ALL_CLEAR_EMPTY = 'All buffers clear; Nothing to send'
@@ -30,6 +34,7 @@ const META_ADD_SUCCESS = 'Successfully added meta property'
 const WARN_LOG_IGNORED = 'Log statement was empty.  Ignored'
 const REMOVE_META_WARN = 'Property is not an existing meta property.  Cannot remove.'
 const REMOVE_META_SUCCESS = 'Successfully removed meta property'
+const INVALID_METHOD = 'Invalid method based on payloadStructure'
 const ERROR_CODES_TO_RETRY = new Set([
   500
 , 'ECONNABORTED' // timeout
@@ -49,7 +54,7 @@ class Logger extends EventEmitter {
     this.flushIntervalMs = constants.FLUSH_INTERVAL_MS
     this.shimProperties = undefined
     this.indexMeta = false
-    this.app = 'default'
+    this.app = constants.PAYLOAD_STRUCTURES.DEFAULT
     this.env = undefined
     this.baseBackoffMs = constants.BASE_BACKOFF_MILLIS
     this.maxBackoffMs = constants.MAX_BACKOFF_MILLIS
@@ -66,6 +71,8 @@ class Logger extends EventEmitter {
     this[kIsSending] = false
     this[kTotalLinesReady] = 0
     this[kBackoffMs] = constants.BASE_BACKOFF_MILLIS
+    this[kPayloadStructure] = constants.PAYLOAD_STRUCTURES.DEFAULT
+    this[kCompress] = false
 
     let useHttps = true
     let withCredentials = false
@@ -268,6 +275,32 @@ class Logger extends EventEmitter {
       transportedBy = ` (${options.UserAgent})`
     }
 
+    if (has(options, 'payloadStructure')) {
+      const val = options.payloadStructure
+      if (!payloads.has(val)) {
+        const err = new TypeError('Invalid payloadStructure value')
+        err.meta = {
+          got: val
+        , expected: [...payloads.keys()]
+        }
+        throw err
+      }
+      this[kPayloadStructure] = val
+    }
+
+    let compressHeader = null
+    if (has(options, 'compress')) {
+      if (this[kPayloadStructure] === constants.PAYLOAD_STRUCTURES.DEFAULT) {
+        const err = new Error('Compression not available')
+        throw err
+      }
+      const compress = Boolean(options.compress)
+      if (compress) {
+        compressHeader = {'Content-Encoding': 'gzip'}
+      }
+      this[kCompress] = compress
+    }
+
     this[kRequestDefaults] = {
       auth: {username: key}
     , agent: useHttps
@@ -277,6 +310,7 @@ class Logger extends EventEmitter {
         ...constants.DEFAULT_REQUEST_HEADER
       , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
       , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
+      , ...compressHeader
       }
     , qs: {
         hostname
@@ -300,6 +334,45 @@ class Logger extends EventEmitter {
     , key
     , value
     })
+  }
+
+  agentLog(options) {
+    options = options || {}
+
+    if (this[kPayloadStructure] !== constants.PAYLOAD_STRUCTURES.AGENT) {
+      const err = new Error(INVALID_METHOD)
+      err.meta = {
+        payloadStructure: this[kPayloadStructure]
+      , expected: constants.PAYLOAD_STRUCTURES.AGENT
+      }
+      this.emit('error', err)
+      return
+    }
+
+    const statement = options.line
+    if (statement === null
+      || statement === undefined
+      || typeof statement === 'string' && !statement.length) {
+
+      this.emit('warn', {
+        message: WARN_LOG_IGNORED
+      , statement
+      })
+      return
+    }
+
+    const payload = {
+      ...payloads.get(constants.PAYLOAD_STRUCTURES.AGENT)
+    , t: Date.now()
+    }
+
+    for (const prop of Object.keys(payload)) {
+      if (has(options, prop)) {
+        payload[prop] = options[prop]
+      }
+    }
+
+    this.bufferLog(payload)
   }
 
   bufferLog(payload) {
@@ -343,6 +416,14 @@ class Logger extends EventEmitter {
     })
   }
 
+  _getSendPayload(data, cb) {
+    if (!this[kCompress]) {
+      setImmediate(cb, null, data)
+      return
+    }
+    zlib.gzip(data, cb)
+  }
+
   log(statement, opts) {
     opts = opts || {}
 
@@ -357,13 +438,22 @@ class Logger extends EventEmitter {
       return
     }
 
+    if (this[kPayloadStructure] !== constants.PAYLOAD_STRUCTURES.DEFAULT) {
+      const err = new Error(INVALID_METHOD)
+      err.meta = {
+        payloadStructure: this[kPayloadStructure]
+      , expected: constants.PAYLOAD_STRUCTURES.DEFAULT
+      }
+      this.emit('error', err)
+      return
+    }
+
     const message = {
-      timestamp: Date.now()
-    , line: undefined
+      ...payloads.get(constants.PAYLOAD_STRUCTURES.DEFAULT)
+    , timestamp: Date.now()
     , level: this.level
     , app: this.app
     , env: this.env
-    , meta: undefined
     }
 
     if (typeof opts === 'string') {
@@ -503,8 +593,10 @@ class Logger extends EventEmitter {
     const config = {
       method: 'post'
     , url: this.url + '?' + querystring.stringify(qs)
-    , headers: this[kRequestDefaults].headers
-    , data: stringify({e: 'ls', ls: buffer})
+    , headers: {
+        ...this[kRequestDefaults].headers // gzipping could mutate headers
+      }
+    , data: undefined
     , timeout: this[kRequestDefaults].timeout
     , withCredentials: this[kRequestDefaults].withCredentials
     , json: true
@@ -522,83 +614,106 @@ class Logger extends EventEmitter {
       ? buffer[buffer.length - 1].line
       : null
 
-    axios(config)
-      .then((response) => {
-        // We have a 200-level success code.
-        const totalLinesSent = buffer.length
-        this[kIsLoggingBackedOff] = false
-        this[kAttempts] = 0
-        this[kIsSending] = false
-        this[kTotalLinesReady] -= totalLinesSent
-        this[kReadyToSend].shift()
+    const data = stringify({e: 'ls', ls: buffer})
 
-        // Assist GC by killing the buffer and removing it from readyToSend
-        buffer.length = 0
-
-        this.emit('send', {
-          httpStatus: response.status
-        , firstLine
-        , lastLine
-        , totalLinesSent
-        , totalLinesReady: this[kTotalLinesReady]
-        , bufferCount: this[kReadyToSend].length
-        })
-
-        if (this[kReadyToSend].length) {
-          // Continue to send any backed up payloads that have accumulated
-          this.send()
-          return
-        }
-
-        this.emit('cleared', {
-          message: ALL_CLEAR_SENT
-        })
-      })
-      .catch((error) => {
-        const code = error.response
-          ? error.response.status
-          : error.code // timeouts will populate this
-
-        const retrying = ERROR_CODES_TO_RETRY.has(code)
-        const err = new Error('An error occured while sending logs to the cloud.')
+    this._getSendPayload(data, (error, payload) => {
+      if (error) {
+        const err = new Error('Error gzipping data')
         err.meta = {
-          actual: error.message
-        , code
-        , firstLine
-        , lastLine
-        , retrying
-        , attempts: ++this[kAttempts]
+          message: 'Will attempt to send data uncompressed'
+        , error
         }
+        // We will still send, but without compression
+        /* eslint no-unused-vars:0 */
+        const {'Content-Encoding': _, ...headers} = config.headers
+        config.headers = headers
+        config.data = data
         this.emit('error', err)
+      } else {
+        config.data = payload
+      }
 
-        if (retrying) {
-          this[kIsLoggingBackedOff] = true
-          this[kBackoffMs] = backoffWithJitter(
-            this.baseBackoffMs
-          , this.maxBackoffMs
-          , this[kBackoffMs]
-          )
-          setTimeout(() => {
-            this.send(false)
-          }, this[kBackoffMs])
-          return
-        }
+      axios(config)
+        .then((response) => {
+          // We have a 200-level success code.
+          const totalLinesSent = buffer.length
+          this[kIsLoggingBackedOff] = false
+          this[kAttempts] = 0
+          this[kIsSending] = false
+          this[kTotalLinesReady] -= totalLinesSent
+          this[kReadyToSend].shift()
 
-        // User-level errors will be discarded since they will never succeed
-        this[kIsSending] = false
-        this[kTotalLinesReady] -= buffer.length
-        this[kAttempts] = 0
-        this[kReadyToSend].shift()
-        buffer.length = 0
-        if (this[kReadyToSend].length) {
-          this.send()
-          return
-        }
+          // Assist GC by killing the buffer and removing it from readyToSend
+          buffer.length = 0
 
-        this.emit('cleared', {
-          message: ALL_CLEAR_SENT
+          this.emit('send', {
+            httpStatus: response.status
+          , firstLine
+          , lastLine
+          , totalLinesSent
+          , totalLinesReady: this[kTotalLinesReady]
+          , bufferCount: this[kReadyToSend].length
+          })
+
+          if (this[kReadyToSend].length) {
+            // Continue to send any backed up payloads that have accumulated
+            this.send()
+            return
+          }
+
+          this.emit('cleared', {
+            message: ALL_CLEAR_SENT
+          })
         })
-      })
+        .catch((error) => {
+          // Allow the microtask queue to unwind in case it's a Promise rejection
+          process.nextTick(() => {
+            const code = error.response
+              ? error.response.status
+              : error.code // timeouts will populate this
+
+            const retrying = ERROR_CODES_TO_RETRY.has(code)
+            const err = new Error('An error occured while sending logs to the cloud.')
+            err.meta = {
+              actual: error.message
+            , code
+            , firstLine
+            , lastLine
+            , retrying
+            , attempts: ++this[kAttempts]
+            }
+            this.emit('error', err)
+
+            if (retrying) {
+              this[kIsLoggingBackedOff] = true
+              this[kBackoffMs] = backoffWithJitter(
+                this.baseBackoffMs
+              , this.maxBackoffMs
+              , this[kBackoffMs]
+              )
+              setTimeout(() => {
+                this.send(false)
+              }, this[kBackoffMs])
+              return
+            }
+
+            // User-level errors will be discarded since they will never succeed
+            this[kIsSending] = false
+            this[kTotalLinesReady] -= buffer.length
+            this[kAttempts] = 0
+            this[kReadyToSend].shift()
+            buffer.length = 0
+            if (this[kReadyToSend].length) {
+              this.send()
+              return
+            }
+
+            this.emit('cleared', {
+              message: ALL_CLEAR_SENT
+            })
+          })
+        })
+    })
   }
 }
 

--- a/lib/payloads.js
+++ b/lib/payloads.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const defaultPayload = {
+  timestamp: undefined
+, line: undefined
+, level: undefined
+, app: undefined
+, env: undefined
+, meta: undefined
+}
+
+const agentPayload = {
+  t: undefined
+, label: undefined
+, line: undefined
+, f: undefined
+, pid: undefined
+, prival: undefined
+, containerid: undefined
+}
+
+module.exports = new Map([
+  ['default', defaultPayload]
+, ['agent', agentPayload]
+])

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -21,6 +21,8 @@ module.exports = function createOptions({
 , baseBackoffMs = undefined
 , maxBackoffMs = undefined
 , meta = undefined
+, payloadStructure = undefined
+, compress = undefined
 } = {}) {
   return {
     key
@@ -42,5 +44,7 @@ module.exports = function createOptions({
   , baseBackoffMs
   , maxBackoffMs
   , meta
+  , payloadStructure
+  , compress
   }
 }

--- a/test/logger-agent-log.js
+++ b/test/logger-agent-log.js
@@ -1,0 +1,370 @@
+'use strict'
+
+const zlib = require('zlib')
+const {test} = require('tap')
+const nock = require('nock')
+const Logger = require('../lib/logger.js')
+const {apiKey, createOptions} = require('./common/index.js')
+
+nock.disableNetConnect()
+
+test('agentLog() success with a /var/log entry', (t) => {
+  const line = 'Aug 27 16:41:30 my-machine com.apple.xpc.launchd[1] (com.apple.mdworker.shared.0D000000-0400-0000-0000-000000000000[11142]): '
+    + 'Service exited due to SIGKILL | sent by mds[116]'
+  const now = Date.now()
+
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload, {
+        line
+      , t: now
+      , f: '/var/log/system.log'
+      })
+      return true
+    })
+    .query(() => {
+      return true
+    })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.agentLog({
+    line
+  , t: now
+  , f: '/var/log/system.log'
+  })
+})
+
+test('agentLog() success while specifying compression off', (t) => {
+  const line = 'Aug 27 16:41:30 my-machine com.apple.xpc.launchd[1] (com.apple.mdworker.shared.0D000000-0400-0000-0000-000000000000[11142]): '
+    + 'Service exited due to SIGKILL | sent by mds[116]'
+  const now = Date.now()
+
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  , compress: false
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload, {
+        line
+      , t: now
+      , f: '/var/log/system.log'
+      })
+      return true
+    })
+    .query(() => {
+      return true
+    })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.agentLog({
+    line
+  , t: now
+  , f: '/var/log/system.log'
+  })
+})
+
+test('agentLog() success with k8s-style line', (t) => {
+  const line = '2020-02-01T05:15:15.000000000-0800 stdout F [200201 05:15:15] [info] {"hello":"world"}'
+  const pid = 12345
+  const prival = 5
+  const label = 'someLabel'
+  const now = Date.now()
+  const file = '/var/log/containers/blarg_myapp_9e0fc8fb-92a3-451c-aea2-'
+    + '9541307d30a2-6c167a350684bb5fe0ff508daea30488d2336164b5407c46ac9866db54ad65e9.log'
+
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls[0]
+      t.deepEqual(payload, {
+        line
+      , t: now
+      , f: file
+      , pid
+      , prival
+      , label
+      })
+      return true
+    })
+    .query(() => {
+      return true
+    })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.agentLog({
+    line
+  , t: now
+  , f: file
+  , pid
+  , prival
+  , label
+  })
+})
+
+test('agentLog() uses gzip compression on the payload', (t) => {
+  const line = 'Aug 27 16:41:30 my-machine com.apple.xpc.launchd[1] (com.apple.mdworker.shared.0D000000-0400-0000-0000-000000000000[11142]): '
+    + 'Service exited due to SIGKILL | sent by mds[116]'
+  const now = Date.now()
+  const payload = {
+    line
+  , t: now
+  , f: '/var/log/system.log'
+  }
+
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  , compress: true
+  , flushIntervalMs: 100
+  }))
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const deflated = zlib.gunzipSync(Buffer.from(body, 'hex')).toString()
+      const parsed = JSON.parse(deflated)
+      t.deepEqual(parsed, {
+        e: 'ls'
+      , ls: [
+          payload
+        , payload
+        , payload
+        ]
+      }, 'Payload was gzipped correctly')
+      return true
+    })
+    .query(() => {
+      return true
+    })
+    .reply(200, 'Ingester response')
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: line
+    , totalLinesSent: 3
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.agentLog(payload)
+  logger.agentLog(payload)
+  logger.agentLog(payload)
+})
+
+test('Error handling: when gzip fails, raw payload is sent instead', (t) => {
+  const line = 'Aug 27 16:41:30 my-machine com.apple.xpc.launchd[1] (com.apple.mdworker.shared.0D000000-0400-0000-0000-000000000000[11142]): '
+    + 'Service exited due to SIGKILL | sent by mds[116]'
+  const now = Date.now()
+  const payload = {
+    line
+  , t: now
+  , f: '/var/log/system.log'
+  }
+  const gzip = zlib.gzip
+
+  t.plan(5)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  , compress: true
+  , flushIntervalMs: 100
+  }))
+
+  zlib.gzip = (_, cb) => {
+    zlib.gzip = gzip
+    setImmediate(cb, new Error('GZIP FAKE FAILURE'))
+  }
+
+  t.on('end', async () => {
+    nock.cleanAll()
+    zlib.gzip = gzip
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      t.type(body, Object, 'POST body is not a compressed string')
+      t.deepEqual(body, {
+        e: 'ls'
+      , ls: [
+          payload
+        ]
+      }, 'Gzip error caused fallback to original data')
+      return true
+    })
+    .query(() => {
+      return true
+    })
+    .reply(function(uri, requestBody, cb) {
+      t.equal(this.req.headers['Content-Encoding'], undefined, 'Gzip header was removed')
+      cb(null, [200, 'Ingester Success'])
+    })
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 200
+    , firstLine: line
+    , lastLine: null
+    , totalLinesSent: 1
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  logger.on('error', (err) => {
+    t.deepEqual(err, {
+      name: 'Error'
+    , message: 'Error gzipping data'
+    , meta: {
+        message: 'Will attempt to send data uncompressed'
+      , error: {
+          name: 'Error'
+        , message: 'GZIP FAKE FAILURE'
+        }
+      }
+    }, 'An error was emitted for the gzip error')
+  })
+
+  logger.agentLog(payload)
+})
+
+test('.agentLog() rejects lines if payloadStructure is not \'agent\'', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions())
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Expected to be a Error')
+    t.match(err, {
+      name: 'Error'
+    , message: 'Invalid method based on payloadStructure'
+    , meta: {
+        payloadStructure: 'default'
+      , expected: 'agent'
+      }
+    }, 'Expected Error is correct')
+  })
+  logger.agentLog('log line')
+})
+
+test('.agentLog() warns if line is blank', async (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  }))
+
+  t.test('Completely blank call - no parameters', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: null
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.agentLog()
+  })
+
+  t.test('Statement is null', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: null
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.agentLog({
+      line: null
+    })
+  })
+
+  t.test('Statement is undefined', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: null
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.agentLog({
+      line: undefined
+    })
+  })
+
+  t.test('Statement is an empty string', (tt) => {
+    tt.plan(1)
+
+    logger.once('warn', (obj) => {
+      tt.deepEqual(obj, {
+        message: 'Log statement was empty.  Ignored'
+      , statement: ''
+      }, `Got warning for ${obj.statement}`)
+    })
+    logger.agentLog({
+      line: ''
+    })
+  })
+})

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -76,15 +76,6 @@ test('.log() throws if options is a string and not a valid log entry', (t) => {
   t.plan(2)
   const logger = new Logger(apiKey, createOptions())
 
-  t.on('end', async () => {
-    nock.cleanAll()
-  })
-
-  nock(logger.url)
-    .post('/', () => { return true })
-    .query(() => { return true })
-    .reply(200, 'Ingester response')
-
   logger.on('error', (err) => {
     t.type(err, TypeError, 'Expected to be a TypeError')
     t.deepEqual(err, {
@@ -102,15 +93,6 @@ test('.log() throws if options is a string and not a valid log entry', (t) => {
 test('.log() rejects invalid `opts` data type', (t) => {
   t.plan(2)
   const logger = new Logger(apiKey, createOptions())
-
-  t.on('end', async () => {
-    nock.cleanAll()
-  })
-
-  nock(logger.url)
-    .post('/', () => { return true })
-    .query(() => { return true })
-    .reply(200, 'Ingester response')
 
   logger.on('error', (err) => {
     t.type(err, TypeError, 'Expected to be a TypeError')
@@ -405,4 +387,24 @@ test('User-level errors are discarded after emitting an error', (t) => {
 
   logger.log('Something is invalid about this line')
   logger.log('Something else is wrong with this line too')
+})
+
+test('.log() rejects lines if payloadStructure is not \'default\'', (t) => {
+  t.plan(2)
+  const logger = new Logger(apiKey, createOptions({
+    payloadStructure: 'agent'
+  }))
+
+  logger.on('error', (err) => {
+    t.type(err, Error, 'Expected to be a Error')
+    t.match(err, {
+      name: 'Error'
+    , message: 'Invalid method based on payloadStructure'
+    , meta: {
+        payloadStructure: 'agent'
+      , expected: 'default'
+      }
+    }, 'Expected Error is correct')
+  })
+  logger.log('log line')
 })


### PR DESCRIPTION
The node client should be able to serve as the transport mechanism
to the ingestion service for anything using nodejs.  LogDNA's agent
can be streamlined by re-using this package (and its retry logic)
to send data to the cloud.  This commit adds a method that should
only be used by the LogDNA agent, but supports the data structure
necessary for ingestion.

Semver: minor
Ref: LOG-7103