### PR TITLE
improvement!: Replace axios with `got` and implement more retry codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ For those cases, additional properties (apart from `message`) are included:
     * `env` [`<String>`][] - An environment label attached to each message
     * `baseBackoffMs` [`<Number>`][] - Minimum exponential backoff time in milliseconds. **Default:** `3000`ms
     * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
-    * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
 * Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]

--- a/docs/migrating-from-other-versions.md
+++ b/docs/migrating-from-other-versions.md
@@ -41,7 +41,7 @@ work, but a `console.warn` will be printed to inform the user to update them.  T
 
 * `logdna_url` is now just `url`
 * `index_meta` is now `indexMeta`
-* `with_credentials` is now `withCredentials`
+* `with_credentials` and `withCredentials` are no longer an option and will throw if used
 * `max_length` is no longer an option and will throw if used
 
 ## What it Looks Like Now

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@ const querystring = require('querystring')
 const {isIP} = require('net')
 const zlib = require('zlib')
 const Agent = require('agentkeepalive')
-const axios = require('axios')
+const got = require('got')
 const stringify = require('json-stringify-safe')
 const constants = require('./constants.js')
 const {checkStringParam, isValidTimestamp, has} = require('./validators/index.js')
@@ -37,7 +37,19 @@ const REMOVE_META_SUCCESS = 'Successfully removed meta property'
 const INVALID_METHOD = 'Invalid method based on payloadStructure'
 const ERROR_CODES_TO_RETRY = new Set([
   500
-, 'ECONNABORTED' // timeout
+, 502
+, 503
+, 504
+, 521
+, 522
+, 524
+, 'ETIMEDOUT'
+, 'ECONNRESET'
+, 'EADDRINUSE'
+, 'ECONNREFUSED'
+, 'EPIPE'
+, 'ENOTFOUND'
+, 'ENETUNREACH'
 ])
 
 class Logger extends EventEmitter {
@@ -74,8 +86,6 @@ class Logger extends EventEmitter {
     this[kPayloadStructure] = constants.PAYLOAD_STRUCTURES.DEFAULT
     this[kCompress] = false
 
-    let useHttps = true
-    let withCredentials = false
     let tags = undefined
     let timeout = constants.DEFAULT_REQUEST_TIMEOUT
     let hostname = os.hostname()
@@ -172,7 +182,6 @@ class Logger extends EventEmitter {
         }
         throw err
       }
-      useHttps = options.url.startsWith('https://')
       this.url = options.url
     }
 
@@ -257,14 +266,9 @@ class Logger extends EventEmitter {
       this.env = options.env
     }
 
-    if (has(options, 'with_credentials')) {
-      console.warn(
-        '[Deprecated] with_credentials is deprecated.  Please use withCredentials.'
-      )
-      options.withCredentials = options.with_credentials
-    }
-    if (has(options, 'withCredentials')) {
-      withCredentials = Boolean(options.withCredentials)
+    if (has(options, 'withCredentials') || has(options, 'with_credentials')) {
+      const err = new Error('The withCredentials option is no longer necessary and has been removed.')
+      throw err
     }
 
     let transportedBy = ''
@@ -303,9 +307,10 @@ class Logger extends EventEmitter {
 
     this[kRequestDefaults] = {
       auth: {username: key}
-    , agent: useHttps
-        ? new Agent.HttpsAgent(constants.AGENT_SETTING)
-        : new Agent(constants.AGENT_SETTING)
+    , agent: {
+        http: new Agent(constants.AGENT_SETTING)
+      , https: new Agent.HttpsAgent(constants.AGENT_SETTING)
+      }
     , headers: {
         ...constants.DEFAULT_REQUEST_HEADER
       , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
@@ -319,8 +324,6 @@ class Logger extends EventEmitter {
       , tags
       }
     , timeout
-    , withCredentials
-    , useHttps
     }
   }
 
@@ -590,35 +593,27 @@ class Logger extends EventEmitter {
     , ...this[kRequestDefaults].qs
     }
 
+    const body = stringify({e: 'ls', ls: buffer})
+
     const config = {
       method: 'post'
     , url: this.url + '?' + querystring.stringify(qs)
     , headers: {
         ...this[kRequestDefaults].headers // gzipping could mutate headers
       }
-    , data: undefined
+    , body: undefined
     , timeout: this[kRequestDefaults].timeout
-    , withCredentials: this[kRequestDefaults].withCredentials
-    , json: true
-    , httpsAgent: undefined
-    , httpAgent: undefined
+    , retry: 0 // Don't use `got` retries. Our retry emits events based on retry data not available with `got` retries
     }
-
-    const agentKey = this[kRequestDefaults].useHttps
-      ? 'httpsAgent'
-      : 'httpAgent'
-    config[agentKey] = this[kRequestDefaults].agent
 
     const firstLine = buffer[0].line
     const lastLine = buffer.length > 1
       ? buffer[buffer.length - 1].line
       : null
 
-    const data = stringify({e: 'ls', ls: buffer})
-
-    this._getSendPayload(data, (error, payload) => {
+    this._getSendPayload(body, (error, payload) => {
       if (error) {
-        const err = new Error('Error gzipping data')
+        const err = new Error('Error gzipping body')
         err.meta = {
           message: 'Will attempt to send data uncompressed'
         , error
@@ -627,13 +622,13 @@ class Logger extends EventEmitter {
         /* eslint no-unused-vars:0 */
         const {'Content-Encoding': _, ...headers} = config.headers
         config.headers = headers
-        config.data = data
+        config.body = body
         this.emit('error', err)
       } else {
-        config.data = payload
+        config.body = payload
       }
 
-      axios(config)
+      got(config)
         .then((response) => {
           // We have a 200-level success code.
           const totalLinesSent = buffer.length
@@ -647,7 +642,7 @@ class Logger extends EventEmitter {
           buffer.length = 0
 
           this.emit('send', {
-            httpStatus: response.status
+            httpStatus: response.statusCode
           , firstLine
           , lastLine
           , totalLinesSent
@@ -669,8 +664,8 @@ class Logger extends EventEmitter {
           // Allow the microtask queue to unwind in case it's a Promise rejection
           process.nextTick(() => {
             const code = error.response
-              ? error.response.status
-              : error.code // timeouts will populate this
+              ? error.response.statusCode
+              : error.code // Connection-level errors will populate this (there will not be a statusCode)
 
             const retrying = ERROR_CODES_TO_RETRY.has(code)
             const err = new Error('An error occured while sending logs to the cloud.')

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "agentkeepalive": "^4.1.3",
-    "axios": "^0.19.0",
+    "got": "^11.5.2",
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -16,8 +16,7 @@ module.exports = function createOptions({
 , timeout = null
 , shimProperties
 , env = undefined
-, withCredentials = null
-, url = `http://localhost:${port}`
+, url = `https://localhost:${port}`
 , baseBackoffMs = undefined
 , maxBackoffMs = undefined
 , meta = undefined
@@ -40,7 +39,6 @@ module.exports = function createOptions({
   , timeout
   , shimProperties
   , env
-  , withCredentials
   , baseBackoffMs
   , maxBackoffMs
   , meta

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -62,7 +62,7 @@ test('Load test to ensure no data loss and expected payloads', async (t) => {
         name: 'Error'
       , message: 'An error occured while sending logs to the cloud.'
       , meta: {
-          actual: 'Request failed with status code 500'
+          actual: 'Response code 500 (Internal Server Error)'
         , code: 500
         , firstLine: line
         , lastLine: line

--- a/test/logger-agent-log.js
+++ b/test/logger-agent-log.js
@@ -233,10 +233,11 @@ test('Error handling: when gzip fails, raw payload is sent instead', (t) => {
   , compress: true
   , flushIntervalMs: 100
   }))
+  const error = new Error('GZIP FAKE FAILURE')
 
   zlib.gzip = (_, cb) => {
     zlib.gzip = gzip
-    setImmediate(cb, new Error('GZIP FAKE FAILURE'))
+    setImmediate(cb, error)
   }
 
   t.on('end', async () => {
@@ -277,13 +278,10 @@ test('Error handling: when gzip fails, raw payload is sent instead', (t) => {
   logger.on('error', (err) => {
     t.deepEqual(err, {
       name: 'Error'
-    , message: 'Error gzipping data'
+    , message: 'Error gzipping body'
     , meta: {
         message: 'Will attempt to send data uncompressed'
-      , error: {
-          name: 'Error'
-        , message: 'GZIP FAKE FAILURE'
-        }
+      , error
       }
     }, 'An error was emitted for the gzip error')
   })

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -76,8 +76,6 @@ test('Logger instance properties', async (t) => {
         , tags: undefined
         }
       , timeout: 5000
-      , withCredentials: false
-      , useHttps: true
       }
     }
     tt.equal(Object.keys(expected).length, symbolCount, 'Each symbol is tested')
@@ -96,7 +94,8 @@ test('Logger instance properties', async (t) => {
     , app: 'default'
     , level: 'INFO'
     , [Symbol.for('requestDefaults')]: {
-        userHttps: true
+        http: Object
+      , https: Object
       }
     })
   })
@@ -114,7 +113,6 @@ test('Logger instance properties', async (t) => {
     , shimProperties: ['one', 'two', 'three']
     , env: 'myEnv'
     , app: 'someAppName'
-    , withCredentials: true
     , url: 'http://localhost:80'
     , ip: ipv6
     , meta: {hey: 'there'}
@@ -136,9 +134,7 @@ test('Logger instance properties', async (t) => {
     , app: options.app
     , url: options.url
     , [Symbol.for('requestDefaults')]: {
-        withCredentials: options.withCredentials
-      , useHttps: false
-      , qs: {
+        qs: {
           hostname: options.hostname
         , mac: options.mac
         , ip: ipv6
@@ -204,20 +200,27 @@ test('Deprecated fields are still allowed and re-assigned', async (t) => {
     })
     tt.equal(log.indexMeta, true, 'indexMeta was set instead')
   })
-
-  t.test('with_credentails is re-assigned to withCredentials', async (tt) => {
-    const log = new Logger(apiKey, {
-      with_credentials: true
-    })
-    tt.equal(
-      log[Symbol.for('requestDefaults')].withCredentials
-    , true
-    , 'withCredentials was set instead'
-    )
-  })
 })
 
 test('Instantiation Errors', async (t) => {
+  t.test('with_credentails and withCredentials have been removed', async (tt) => {
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        with_credentials: true
+      })
+    }, {
+      message: 'The withCredentials option is no longer necessary and has been removed.'
+    }, 'Expected error thrown for with_credentials')
+
+    tt.throws(() => {
+      return new Logger(apiKey, {
+        withCredentials: true
+      })
+    }, {
+      message: 'The withCredentials option is no longer necessary and has been removed.'
+    }, 'Expected error thrown for withCredentials')
+  })
+
   t.test('Auth key is required', async (tt) => {
     tt.throws(() => {
       return new Logger()

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -758,11 +758,10 @@ test('removeMetaProperty() removes it from the payload; indexMeta: false', (t) =
 })
 
 test('Can call .log with HTTP (not https)', (t) => {
-  t.plan(2)
+  t.plan(1)
   const logger = new Logger(apiKey, createOptions({
-    protocol: 'http'
+    url: 'http://localhost:12345'
   }))
-  t.equal(logger[Symbol.for('requestDefaults')].useHttps, false, 'HTTPS is off')
   t.on('end', async () => {
     nock.cleanAll()
   })

--- a/types.d.ts
+++ b/types.d.ts
@@ -25,7 +25,6 @@ declare module "logdna" {
     env?: string;
     baseBackoffMs?: number;
     maxBackoffMs?: number;
-    withCredentials?: boolean;
   }
 
   interface LogOptions {


### PR DESCRIPTION
BREAKING CHANGE: `withCredentials` was an axios-specific option.

`got` as an HTTP agent has more active support and potentially
fixes stream issues (if we ever move towards gzip streams).  Although
`got` has builtin retry logic, the client already had logic and
events for the same thing, so switching it out didn't seem necessary.
This change does, however, implement retries based on the same list
of status codes and connection codes that `got` uses.

Because of the removal of axios-specific options, this is a major
release, but technically has no changes.

Semver: major
Ref: LOG-7113