### PR TITLE
improvement: Add more error retry codes, and handle 207 partial-success responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,24 @@ When the send queue is empty, `cleared` is emitted.
 
 ### Handling Errors
 
-* `timeout` or `500` errors will be retried using an [exponential backoff strategy](#exponential-backoff-strategy), but will
+* Connection-based errors or `500`-level response status codes will be retried using an [exponential backoff strategy](#exponential-backoff-strategy), but will
   also emit `error` events along the way.
+    * Connection error codes that will retry:
+      `ECONNABORTED` (timeout),
+      `ECONNRESET`,
+      `EADDRINUSE`,
+      `ECONNREFUSED`,
+      `EPIPE`,
+      `ENOTFOUND`,
+      `ENETUNREACH`
+    * HTTP status codes that will retry:
+      `500`,
+      `502`,
+      `503`,
+      `504`,
+      `521`,
+      `522`,
+      `524`
 * User-level errors (such as `400`) will not be retried because they most likely would never be successful (if the message is deemed invalid),
   and `error` events are emitted for these errors, also.
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -37,7 +37,19 @@ const REMOVE_META_SUCCESS = 'Successfully removed meta property'
 const INVALID_METHOD = 'Invalid method based on payloadStructure'
 const ERROR_CODES_TO_RETRY = new Set([
   500
+, 502
+, 503
+, 504
+, 521
+, 522
+, 524
 , 'ECONNABORTED' // timeout
+, 'ECONNRESET'
+, 'EADDRINUSE'
+, 'ECONNREFUSED'
+, 'EPIPE'
+, 'ENOTFOUND'
+, 'ENETUNREACH'
 ])
 
 class Logger extends EventEmitter {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -35,6 +35,9 @@ const WARN_LOG_IGNORED = 'Log statement was empty.  Ignored'
 const REMOVE_META_WARN = 'Property is not an existing meta property.  Cannot remove.'
 const REMOVE_META_SUCCESS = 'Successfully removed meta property'
 const INVALID_METHOD = 'Invalid method based on payloadStructure'
+const LINE_INGEST_ERROR = 'Non-200 status while ingesting this line'
+const PARTIAL_SUCCESS_CODE = 207
+const SUCCESS_CODE = 200
 const ERROR_CODES_TO_RETRY = new Set([
   500
 , 502
@@ -648,11 +651,27 @@ class Logger extends EventEmitter {
       axios(config)
         .then((response) => {
           // We have a 200-level success code.
-          const totalLinesSent = buffer.length
+          let totalLinesSent = buffer.length
+
+          if (response.status === PARTIAL_SUCCESS_CODE) {
+            const statusCodes = response.data.status || []
+
+            for (let i = 0; i < statusCodes.length; i++) {
+              if (statusCodes[i] === SUCCESS_CODE) continue
+              totalLinesSent--
+              const err = new Error(LINE_INGEST_ERROR)
+              err.meta = {
+                statusCode: statusCodes[i]
+              , line: buffer[i].line
+              }
+              this.emit('error', err)
+            }
+          }
+
           this[kIsLoggingBackedOff] = false
           this[kAttempts] = 0
           this[kIsSending] = false
-          this[kTotalLinesReady] -= totalLinesSent
+          this[kTotalLinesReady] -= buffer.length
           this[kReadyToSend].shift()
 
           // Assist GC by killing the buffer and removing it from readyToSend

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -270,72 +270,176 @@ test('HTTP timeout will emit Error and continue to retry', (t) => {
   logger.log('This will cause an HTTP timeout')
 })
 
-test('A 500-error will continue to retry', (t) => {
+test('A 500-level statusCode error will continue to retry', (t) => {
   const logger = new Logger(apiKey, createOptions({
-    baseBackoffMs: 100
-  , maxBackoffMs: 500
+    baseBackoffMs: 50
+  , maxBackoffMs: 100
   }))
-  let attempts = 0
 
-  t.on('end', async () => {
-    nock.cleanAll()
-  })
+  const codes = [
+    500
+  , 502
+  , 503
+  , 504
+  , 521
+  , 522
+  , 524
+  ]
 
-  // Fail 3 times, then succeed
-  nock(logger.url)
-    .post('/', () => {
-      t.equal(
-        logger[Symbol.for('isLoggingBackedOff')]
-      , false
-      , 'Logger is not backed off prior to the first failure'
-      )
-      return true
+  codes.forEach((code) => {
+    t.test(`Testing with statusCode: ${code}`, (tt) => {
+      let attempts = 0
+
+      tt.on('end', async () => {
+        nock.cleanAll()
+        logger.removeAllListeners()
+      })
+
+      // Fail 3 times, then succeed
+      nock(logger.url)
+        .post('/', () => {
+          tt.equal(
+            logger[Symbol.for('isLoggingBackedOff')]
+          , false
+          , 'Logger is not backed off prior to the first failure'
+          )
+          return true
+        })
+        .query(() => { return true })
+        .reply(code, 'SERVER KABOOM')
+        .post('/', () => {
+          tt.equal(
+            logger[Symbol.for('isLoggingBackedOff')]
+          , true
+          , 'Logger is backed off'
+          )
+          return true
+        })
+        .query(() => { return true })
+        .reply(code, 'SERVER KABOOM')
+        .post('/', () => { return true })
+        .query(() => { return true })
+        .reply(code, 'SERVER KABOOM')
+        .post('/', () => { return true })
+        .query(() => { return true })
+        .reply(200, 'Success')
+
+      logger.on('error', (err) => {
+        tt.type(err, Error, 'Error type is emitted')
+        tt.match(err, {
+          message: 'An error occured while sending logs to the cloud.'
+        , meta: {
+            actual: `Request failed with status code ${code}`
+          , code
+          , firstLine: 'This will cause a server 500ish error'
+          , lastLine: null
+          , retrying: true
+          , attempts: ++attempts
+          }
+        }, `Error properties are correct for attempt ${attempts}`)
+      })
+
+      logger.on('cleared', ({message}) => {
+        tt.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+        tt.equal(
+          logger[Symbol.for('isLoggingBackedOff')]
+        , false
+        , 'Logger is not backed off after having a successful connection'
+        )
+        tt.end()
+      })
+
+      logger.log('This will cause a server 500ish error')
     })
-    .query(() => { return true })
-    .reply(500, 'SERVER KABOOM')
-    .post('/', () => {
-      t.equal(
-        logger[Symbol.for('isLoggingBackedOff')]
-      , true
-      , 'Logger is backed off'
-      )
-      return true
+  })
+
+  t.end()
+})
+
+test('Connection-based error codes trigger a retry', (t) => {
+  const logger = new Logger(apiKey, createOptions({
+    baseBackoffMs: 50
+  , maxBackoffMs: 100
+  }))
+
+  const codes = [
+    'ECONNABORTED'
+  , 'ECONNRESET'
+  , 'EADDRINUSE'
+  , 'ECONNREFUSED'
+  , 'EPIPE'
+  , 'ENOTFOUND'
+  , 'ENETUNREACH'
+  ]
+
+  codes.forEach((code) => {
+    t.test(`Testing with connection error: ${code}`, (tt) => {
+      let attempts = 0
+
+      tt.on('end', async () => {
+        nock.cleanAll()
+        logger.removeAllListeners()
+      })
+
+      // Fail 3 times, then succeed
+      nock(logger.url)
+        .post('/', () => {
+          tt.equal(
+            logger[Symbol.for('isLoggingBackedOff')]
+          , false
+          , 'Logger is not backed off prior to the first failure'
+          )
+          return true
+        })
+        .query(() => { return true })
+        .replyWithError({code})
+        .post('/', () => {
+          tt.equal(
+            logger[Symbol.for('isLoggingBackedOff')]
+          , true
+          , 'Logger is backed off'
+          )
+          return true
+        })
+        .query(() => { return true })
+        .replyWithError({code})
+        .post('/', () => { return true })
+        .query(() => { return true })
+        .replyWithError({code})
+        .post('/', () => { return true })
+        .query(() => { return true })
+        .reply(200, 'Success')
+
+      logger.on('error', (err) => {
+        tt.type(err, Error, 'Error type is emitted')
+        tt.match(err, {
+          message: 'An error occured while sending logs to the cloud.'
+        , meta: {
+            actual: undefined
+          , code
+          , firstLine: 'This will cause an HTTP connection error'
+          , lastLine: null
+          , retrying: true
+          , attempts: ++attempts
+          }
+        }, `Error properties are correct for attempt ${attempts}`)
+      })
+
+      logger.on('cleared', ({message}) => {
+        tt.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+        tt.equal(
+          logger[Symbol.for('isLoggingBackedOff')]
+        , false
+        , 'Logger is not backed off after having a successful connection'
+        )
+        tt.end()
+      })
+
+      logger.log('This will cause an HTTP connection error')
     })
-    .query(() => { return true })
-    .reply(500, 'SERVER KABOOM')
-    .post('/', () => { return true })
-    .query(() => { return true })
-    .reply(500, 'SERVER KABOOM')
-    .post('/', () => { return true })
-    .query(() => { return true })
-    .reply(200, 'Success')
-
-  logger.on('error', (err) => {
-    t.type(err, Error, 'Error type is emitted')
-    t.match(err, {
-      message: 'An error occured while sending logs to the cloud.'
-    , meta: {
-        actual: 'Request failed with status code 500'
-      , code: 500
-      , firstLine: 'This will cause an HTTP timeout'
-      , lastLine: null
-      , retrying: true
-      , attempts: ++attempts
-      }
-    }, `Error properties are correct for attempt ${attempts}`)
   })
 
-  logger.on('cleared', ({message}) => {
-    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
-    t.equal(
-      logger[Symbol.for('isLoggingBackedOff')]
-    , false
-    , 'Logger is not backed off after having a successful connection'
-    )
-    t.end()
-  })
-
-  logger.log('This will cause an HTTP timeout')
+  t.end()
 })
 
 test('User-level errors are discarded after emitting an error', (t) => {

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -919,3 +919,119 @@ test('flush() can be called any time, and always emits \'cleared\'', (t) => {
   logger.flush()
   logger.flush()
 })
+
+test('207 partial-success responses emit errors for the failed lines', (t) => {
+  t.plan(5)
+
+  const logger = new Logger(apiKey, createOptions({
+    flushIntervalMs: 500
+  }))
+  const lines = [
+    'This is the first line, which will succeeed'
+  , 'THIS LINE WILL FAIL'
+  , 'This line should succeed'
+  , 'THIS LINE WILL FAIL TOO'
+  ]
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      const payload = body.ls
+      t.equal(payload.length, 4, 'Payload has the right number of entries')
+      t.match(payload, [
+        {line: lines[0]}
+      , {line: lines[1]}
+      , {line: lines[2]}
+      , {line: lines[3]}
+      ])
+      return true
+    })
+    .query(() => { return true })
+    .reply(207, {status: [200, 400, 200, 418]})
+
+  logger.on('error', (err) => {
+    if (err.meta.line !== lines[1]) return
+    t.deepEqual(err, {
+      name: 'Error'
+    , message: 'Non-200 status while ingesting this line'
+    , meta: {
+        statusCode: 400
+      , line: lines[1]
+      }
+    }, 'Got an error event for line 2')
+  })
+
+  logger.on('error', (err) => {
+    if (err.meta.line !== lines[3]) return
+    t.deepEqual(err, {
+      name: 'Error'
+    , message: 'Non-200 status while ingesting this line'
+    , meta: {
+        statusCode: 418
+      , line: lines[3]
+      }
+    }, 'Got an error event for line 4')
+  })
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 207
+    , firstLine: lines[0]
+    , lastLine: lines[3]
+    , totalLinesSent: 2
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  for (const line of lines) {
+    logger.info(line)
+  }
+})
+
+test('207 partial-success responses can be parsed without status codes', (t) => {
+  t.plan(1)
+
+  const logger = new Logger(apiKey, createOptions({
+    flushIntervalMs: 500
+  }))
+  const lines = [
+    'This is the first line, which will succeeed'
+  , 'THIS LINE WILL FAIL'
+  , 'This line should succeed'
+  , 'THIS LINE WILL FAIL TOO'
+  ]
+
+  t.on('end', async () => {
+    nock.cleanAll()
+  })
+
+  nock(logger.url)
+    .post('/', (body) => {
+      return true
+    })
+    .query(() => { return true })
+    .reply(207)
+
+  logger.on('error', () => {
+    t.fail('This test should not emit errors because there are no returned status codes')
+  })
+
+  logger.on('send', (obj) => {
+    t.deepEqual(obj, {
+      httpStatus: 207
+    , firstLine: lines[0]
+    , lastLine: lines[3]
+    , totalLinesSent: 4
+    , totalLinesReady: 0
+    , bufferCount: 0
+    }, 'Got send event')
+  })
+
+  for (const line of lines) {
+    logger.info(line)
+  }
+})


### PR DESCRIPTION
**improvement: Handle partial-success 207 responses**

If we get a partial-success (207) response, emit errors for
the failed lines.  This maintains feature parity with the agent
in preparation for using this client inside of the agent.

Semver: minor
Ref: LOG-7151

---

**improvement: Add more error codes for retry**

This change enhances our list of error codes for status as well as
connection-based error codes.  This will allow the client to be more
intelligent about when to retry.

Semver: minor
Ref: LOG-7151
