### PR TITLE
Fix module name in types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-declare module "logdna" {
+declare module "@logdna/logger" {
   enum LogLevel {
     trace,
     debug,


### PR DESCRIPTION
Type definitions were using old module name (logdna)

Changes the module name to @logdna/logger