### PR TITLE
feat: Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 * **[Bunyan Stream](#bunyan-stream)**
 * **[Winston Transport](#winston-transport)**
 * **[AWS Lambda Support](#aws-lambda-support)**
+* **[Proxy Support](#proxy-support)**
 * **[License](#license)**
 
 ## Migrating From Other Versions
@@ -266,6 +267,7 @@ For those cases, additional properties (apart from `message`) are included:
     * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
+    * `proxy` [`<String>`][] - The full URL of an http or https proxy to pass through
 * Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]
 * Returns: `Logger`
 
@@ -542,6 +544,27 @@ exports.handler = (event, context, callback) => {
 }
 ```
 
+## Proxy Support
+
+The logger supports proxying for situations such as corporate proxies that require traffic
+to be passed through them before reaching the outside world.  For such implementations,
+use the [`proxy` instantiation option](#createloggerkey-options) to set the full URL
+of the proxy.  It supports both *http* and *https* proxy URLs.  Under the hood, the logger uses
+the [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) package for this.
+
+In this example, an http proxy (with credentials) is passed through before reaching LogDNA's
+secure ingestion endpoint:
+
+```javascript
+const {createLogger} = require('@logdna/logger')
+
+const logger = createLogger(apiKey, {
+  proxy: 'http://username:pass@yourproxy.company.com:12345'
+, app: 'myapp'
+})
+
+logger.info('Happy logging through your proxy!')
+```
 
 ## License
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,6 @@ module.exports = {
   AGENT_SETTING: {maxSockets: 20, freeSocketTimeout: 60000}
 , BASE_BACKOFF_MILLIS: 3000
 , MAX_BACKOFF_MILLIS: 30000
-, DEFAULT_REQUEST_HEADER: {'Content-Type': 'application/json; charset=UTF-8'}
 , DEFAULT_REQUEST_TIMEOUT: 5000
 , USER_AGENT: `${pkg.name}/${pkg.version}`
 , FLUSH_BYTE_LIMIT: 5000000

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,6 +8,7 @@ const zlib = require('zlib')
 const Agent = require('agentkeepalive')
 const axios = require('axios')
 const stringify = require('json-stringify-safe')
+const HttpsProxyAgent = require('https-proxy-agent')
 const constants = require('./constants.js')
 const {checkStringParam, isValidTimestamp, has} = require('./validators/index.js')
 const backoffWithJitter = require('./backoff-with-jitter.js')
@@ -316,13 +317,24 @@ class Logger extends EventEmitter {
       this[kCompress] = compress
     }
 
+    let agent = useHttps
+      ? new Agent.HttpsAgent(constants.AGENT_SETTING)
+      : new Agent(constants.AGENT_SETTING)
+
+    if (has(options, 'proxy')) {
+      if (typeof options.proxy !== 'string' || !constants.PROTOCOL_RE.test(options.proxy)) {
+        const err = new TypeError('proxy value must be a full http or https URL')
+        err.meta = {got: options.proxy}
+        throw err
+      }
+      agent = new HttpsProxyAgent(options.proxy)
+    }
+
     this[kRequestDefaults] = {
       auth: {username: key}
-    , agent: useHttps
-        ? new Agent.HttpsAgent(constants.AGENT_SETTING)
-        : new Agent(constants.AGENT_SETTING)
+    , agent
     , headers: {
-        ...constants.DEFAULT_REQUEST_HEADER
+        'Content-Type': 'application/json; charset=UTF-8'
       , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
       , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
       , ...compressHeader
@@ -648,7 +660,7 @@ class Logger extends EventEmitter {
         config.data = payload
       }
 
-      axios(config)
+      axios.request(config)
         .then((response) => {
           // We have a 200-level success code.
           let totalLinesSent = buffer.length

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   },
   "dependencies": {
     "agentkeepalive": "^4.1.3",
-    "axios": "^0.19.0",
+    "axios": "^0.20.0",
+    "https-proxy-agent": "^5.0.0",
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -17,12 +17,13 @@ module.exports = function createOptions({
 , shimProperties
 , env = undefined
 , withCredentials = null
-, url = `http://localhost:${port}`
+, url = `https://localhost:${port}`
 , baseBackoffMs = undefined
 , maxBackoffMs = undefined
 , meta = undefined
 , payloadStructure = undefined
 , compress = undefined
+, proxy = undefined
 } = {}) {
   return {
     key
@@ -46,5 +47,6 @@ module.exports = function createOptions({
   , meta
   , payloadStructure
   , compress
+  , proxy
   }
 }


### PR DESCRIPTION
Certain implementations may require traffic to pass through a proxy
before reaching the outside world (and the LogDNA server).  This
uses the `https-proxy-agent` package to add proxy capability
to the HTTP agent.

Semver: minor
Ref: LOG-7175