### PR TITLE
package: Add pre-commit hooks to enforce commit message style

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,63 @@
       "ecmaVersion": 2019
     }
   },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "commitlint": {
+    "rules": {
+      "body-leading-blank": [
+        2,
+        "always"
+      ],
+      "body-max-line-length": [
+        2,
+        "always",
+        72
+      ],
+      "body-min-length": [
+        2,
+        "always",
+        20
+      ],
+      "subject-max-length": [
+        2,
+        "always",
+        72
+      ],
+      "scope-empty": [
+        2,
+        "always"
+      ],
+      "subject-full-stop": [
+        2,
+        "never",
+        "."
+      ],
+      "type-enum": [
+        2,
+        "always",
+        [
+          "feat",
+          "deps",
+          "fix",
+          "docs",
+          "package",
+          "style",
+          "refactor",
+          "test",
+          "revert",
+          "WIP"
+        ]
+      ],
+      "type-empty": [
+        2,
+        "never"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -60,9 +117,12 @@
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^9.1.2",
+    "@commitlint/config-conventional": "^9.1.2",
     "eslint": "^7.4.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-sensible": "^2.2.0",
+    "husky": "^4.2.5",
     "nock": "^13.0.2",
     "tap": "^14.10.8"
   }


### PR DESCRIPTION
We should do our best to enforce our desired conventional
commit style, especially since PRs may come from the
public.  This sets up basic rules for validating the
conventional commit style.

Semver: minor
Ref: LOG-7183