### PR TITLE
fix: Remove eslint as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "url": "https://github.com/logdna/logger-node/issues"
   },
   "homepage": "https://github.com/logdna/logger-node#readme",
-  "peerDependencies": {
-    "eslint": ">= 6"
-  },
   "eslintConfig": {
     "root": true,
     "ignorePatterns": [


### PR DESCRIPTION
eslint does not need to be a peerDependency.  It will work fine
as a dev dependency.

Ref: LOG-7287
Fixes: https://github.com/logdna/logger-node/issues/18
Semver: patch