### PR TITLE
Don't set 'user-agent' header when running in browser

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -330,15 +330,27 @@ class Logger extends EventEmitter {
       agent = new HttpsProxyAgent(options.proxy)
     }
 
+    const headers = {
+      'Content-Type': 'application/json; charset=UTF-8'
+    , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
+    , ...compressHeader
+    }
+
+    // Only set 'user-agent' header if we're not running in a browser as
+    // attempting to set that header on a browser will cause the request to be
+    // blocked.
+    //
+    // See
+    // https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+    // for more information.
+    if (typeof window === 'undefined') {
+      headers['user-agent'] = `${constants.USER_AGENT}${transportedBy}`
+    }
+
     this[kRequestDefaults] = {
       auth: {username: key}
     , agent
-    , headers: {
-        'Content-Type': 'application/json; charset=UTF-8'
-      , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
-      , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
-      , ...compressHeader
-      }
+    , headers
     , qs: {
         hostname
       , mac


### PR DESCRIPTION
Hi! 👋 

I'm attempting to use your client in the browser but I'm running into an issue where the logs are failing to be sent due to the client attempting to set the `user-agent` header (which is the same issue raised in #21).

I've forked the client and published that version to workaround this issue for now; however it would be great if this fix was merged upstream so I don't have to maintain a forked version.

My fix conditionally sets the `user-agent` header only if the client isn't running in the browser (which I detect by simply checking if the `window` variable is undefined).

Feel free to modify this code if you'd prefer to have your own version of the fix (it's a fairly straightforward change) or close this if you'd prefer a different solution, just thought I'd contribute my solution in case it's helpful!