### PR TITLE
feat: `ignoreRetryableErrors` will not emit retry-able errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,16 @@ then the message will be `'All accumulated log entries have been sent'`. If ther
     * `meta` [`<Object>`][] - Meta object populated with different information depending on the error
 
 This event is emitted when an asynchronous error is encountered. Depending on the context, `meta` will contain
-different pieces of information about the error.
+different pieces of information about the error.  If the error is retry-able, the error's `message`
+property will indicate that it's a "temporary" error to avoid confusion with hard errors.
 
 #### Error while sending to LogDNA
 
-The metadata for an error encountered during an HTTP call to LogDNA will have the following `meta` properties in the error:
+**Note:** `ignoreRetryableErrors` is `true` by default, and will not emit errors when
+the `retrying` property in the metadata is `true`.  To emit all errors regardless of
+`retrying`, set `ignoreRetryableErrors: false`.
+
+The metadata for an error encountered during an HTTP call to LogDNA will have the following `meta` properties in the error.
 
 * `actual` [`<String>`][] - The raw error message from the HTTP client
 * `code` [`<String>`][] | [`<Number>`][] - The HTTP agent's "code" or `statusCode` value
@@ -268,6 +273,8 @@ For those cases, additional properties (apart from `message`) are included:
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
     * `proxy` [`<String>`][] - The full URL of an http or https proxy to pass through
+    * `ignoreRetryableErrors` [`<Boolean>`][] - Do not emit "errors" that are retry-able. Typically, theses are
+      temporary connection-based errors. **Default:** `true`
 * Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]
 * Returns: `Logger`
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -28,6 +28,7 @@ const kTotalLinesReady = Symbol.for('totalLinesReady')
 const kBackoffMs = Symbol('backoffMs')
 const kPayloadStructure = Symbol('payloadStructure')
 const kCompress = Symbol('compress')
+const kIgnoreRetryableErrors = Symbol.for('ignoreRetryableErrors')
 
 const ALL_CLEAR_SENT = 'All accumulated log entries have been sent'
 const ALL_CLEAR_EMPTY = 'All buffers clear; Nothing to send'
@@ -89,6 +90,7 @@ class Logger extends EventEmitter {
     this[kBackoffMs] = constants.BASE_BACKOFF_MILLIS
     this[kPayloadStructure] = constants.PAYLOAD_STRUCTURES.DEFAULT
     this[kCompress] = false
+    this[kIgnoreRetryableErrors] = true
 
     let useHttps = true
     let withCredentials = false
@@ -315,6 +317,10 @@ class Logger extends EventEmitter {
         compressHeader = {'Content-Encoding': 'gzip'}
       }
       this[kCompress] = compress
+    }
+
+    if (has(options, 'ignoreRetryableErrors')) {
+      this[kIgnoreRetryableErrors] = Boolean(options.ignoreRetryableErrors)
     }
 
     let agent = useHttps
@@ -717,8 +723,7 @@ class Logger extends EventEmitter {
               : error.code // timeouts will populate this
 
             const retrying = ERROR_CODES_TO_RETRY.has(code)
-            const err = new Error('An error occured while sending logs to the cloud.')
-            err.meta = {
+            const errorMeta = {
               actual: error.message
             , code
             , firstLine
@@ -726,7 +731,6 @@ class Logger extends EventEmitter {
             , retrying
             , attempts: ++this[kAttempts]
             }
-            this.emit('error', err)
 
             if (retrying) {
               this[kIsLoggingBackedOff] = true
@@ -738,8 +742,25 @@ class Logger extends EventEmitter {
               setTimeout(() => {
                 this.send(false)
               }, this[kBackoffMs])
+
+              if (this[kIgnoreRetryableErrors]) return
+
+              const err = new Error(
+                'Temporary connection-based error. It will be retried. '
+                  + 'See meta data for details.'
+              )
+              err.meta = errorMeta
+              this.emit('error', err)
+
               return
             }
+
+            const err = new Error(
+              'A connection-based error occurred that will not be retried. '
+                + 'See meta data for details.'
+            )
+            err.meta = errorMeta
+            this.emit('error', err)
 
             // User-level errors will be discarded since they will never succeed
             this[kIsSending] = false

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -24,6 +24,7 @@ module.exports = function createOptions({
 , payloadStructure = undefined
 , compress = undefined
 , proxy = undefined
+, ignoreRetryableErrors = undefined
 } = {}) {
   return {
     key
@@ -48,5 +49,6 @@ module.exports = function createOptions({
   , payloadStructure
   , compress
   , proxy
+  , ignoreRetryableErrors
   }
 }

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -42,6 +42,7 @@ test('Load test to ensure no data loss and expected payloads', async (t) => {
     , baseBackoffMs: 100
     , maxBackoffMs: 500
     , url: `http://localhost:${server.address().port}`
+    , ignoreRetryableErrors: false
     })
 
     logger.on('send', (evt) => {
@@ -60,7 +61,8 @@ test('Load test to ensure no data loss and expected payloads', async (t) => {
       errorEvents++
       tt.deepEqual(evt, {
         name: 'Error'
-      , message: 'An error occured while sending logs to the cloud.'
+      , message: 'Temporary connection-based error. It will be retried. '
+          + 'See meta data for details.'
       , meta: {
           actual: 'Request failed with status code 500'
         , code: 500

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -57,6 +57,7 @@ test('Logger instance properties', async (t) => {
     , 'Symbol(backoffMs)': 3000
     , 'Symbol(payloadStructure)': 'default'
     , 'Symbol(compress)': false
+    , 'Symbol(ignoreRetryableErrors)': true
     , 'Symbol(requestDefaults)': {
         auth: {
           username: apiKey
@@ -119,7 +120,7 @@ test('Logger instance properties', async (t) => {
     })
   })
 
-  t.test('Check default property values', async (tt) => {
+  t.test('Check default property values of properties', async (tt) => {
     const log = new Logger(apiKey)
     tt.match(log, {
       flushLimit: 5000000
@@ -133,6 +134,7 @@ test('Logger instance properties', async (t) => {
     , [Symbol.for('requestDefaults')]: {
         userHttps: true
       }
+    , [Symbol.for('ignoreRetryableErrors')]: true
     })
   })
 
@@ -156,6 +158,7 @@ test('Logger instance properties', async (t) => {
     , hostname: 'bleck'
     , mac: '01:02:03:04:05:06'
     , tags: ['whiz', 'bang', 'done']
+    , ignoreRetryableErrors: false
     })
     const log = new Logger(apiKey, options)
 
@@ -181,6 +184,7 @@ test('Logger instance properties', async (t) => {
         }
       , timeout: options.timeout
       }
+    , [Symbol.for('ignoreRetryableErrors')]: false
     }
 
     tt.match(log, expected, 'Provided values were used in instantiation')


### PR DESCRIPTION
BREAKING CHANGE: The 'error' event's message was changed

Retry-able errors can get noisy considering they're
typically related to intermittent client/server errors
(currently being addressed), and there is no loss of data.
Rather than swallowing these errors, the user should be able
to control how noisy the errors are.  The default will be to
NOT emit retry-able errors.

To reduce confusion between irrecoverable errors, the `Error`
message was changed to reflect whether or not it's a temporary (or
retry-able) error.  Although minor, this is considered a breaking
change.

Semver: major
Ref: LOG-7639
Fixes: https://github.com/logdna/logger-node/issues/24