### PR TITLE
fix: Omit user-agent header if `sendUserAgent` option is `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ For those cases, additional properties (apart from `message`) are included:
     * `proxy` [`<String>`][] - The full URL of an http or https proxy to pass through
     * `ignoreRetryableErrors` [`<Boolean>`][] - Do not emit "errors" that are retry-able. Typically, theses are
       temporary connection-based errors. **Default:** `true`
+    * `sendUserAgent` [`<Boolean>`][] - This option controls the sending of our library's user-agent string
+      in HTTP requests to LogDNA. When this setting is `true` in a browser context, it may print a console
+      error although the payloads are still sent.  Setting this to `false` in a browser context will
+      retain the `user-agent` header of the browser. **Default:** `true`
 * Throws: [`<TypeError>`][] | [`<TypeError>`][] | [`<Error>`][]
 * Returns: `Logger`
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,6 +29,7 @@ const kBackoffMs = Symbol('backoffMs')
 const kPayloadStructure = Symbol('payloadStructure')
 const kCompress = Symbol('compress')
 const kIgnoreRetryableErrors = Symbol.for('ignoreRetryableErrors')
+const kUserAgentHeader = Symbol.for('userAgentHeader')
 
 const ALL_CLEAR_SENT = 'All accumulated log entries have been sent'
 const ALL_CLEAR_EMPTY = 'All buffers clear; Nothing to send'
@@ -75,6 +76,7 @@ class Logger extends EventEmitter {
     this.env = undefined
     this.baseBackoffMs = constants.BASE_BACKOFF_MILLIS
     this.maxBackoffMs = constants.MAX_BACKOFF_MILLIS
+    this.sendUserAgent = true
 
     // Initialize internal instance variables
     this[kLineLengthTotal] = 0
@@ -323,6 +325,10 @@ class Logger extends EventEmitter {
       this[kIgnoreRetryableErrors] = Boolean(options.ignoreRetryableErrors)
     }
 
+    if (has(options, 'sendUserAgent')) {
+      this.sendUserAgent = Boolean(options.sendUserAgent)
+    }
+
     let agent = useHttps
       ? new Agent.HttpsAgent(constants.AGENT_SETTING)
       : new Agent(constants.AGENT_SETTING)
@@ -337,12 +343,13 @@ class Logger extends EventEmitter {
       agent = new HttpsProxyAgent(options.proxy)
     }
 
+    this[kUserAgentHeader] = `${constants.USER_AGENT}${transportedBy}`
+
     this[kRequestDefaults] = {
       auth: {username: key}
     , agent
     , headers: {
         'Content-Type': 'application/json; charset=UTF-8'
-      , 'user-agent': `${constants.USER_AGENT}${transportedBy}`
       , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
       , ...compressHeader
       }
@@ -636,6 +643,12 @@ class Logger extends EventEmitter {
     , json: true
     , httpsAgent: undefined
     , httpAgent: undefined
+    }
+
+    // Setting this to `false` can avoid the browser console error of:
+    // Refused to set unsafe header "user-agent"
+    if (this.sendUserAgent) {
+      config.headers['user-agent'] = this[kUserAgentHeader]
     }
 
     const agentKey = this[kRequestDefaults].useHttps

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -25,6 +25,7 @@ module.exports = function createOptions({
 , compress = undefined
 , proxy = undefined
 , ignoreRetryableErrors = undefined
+, sendUserAgent = undefined
 } = {}) {
   return {
     key
@@ -50,5 +51,6 @@ module.exports = function createOptions({
   , compress
   , proxy
   , ignoreRetryableErrors
+  , sendUserAgent
   }
 }

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const {test} = require('tap')
-const pkg = require('../package.json')
 const Logger = require('../lib/logger.js')
 const constants = require('../lib/constants.js')
 const payloads = require('../lib/payloads.js')
@@ -58,6 +57,7 @@ test('Logger instance properties', async (t) => {
     , 'Symbol(payloadStructure)': 'default'
     , 'Symbol(compress)': false
     , 'Symbol(ignoreRetryableErrors)': true
+    , 'Symbol(userAgentHeader)': constants.USER_AGENT
     , 'Symbol(requestDefaults)': {
         auth: {
           username: apiKey
@@ -65,7 +65,6 @@ test('Logger instance properties', async (t) => {
       , agent: Object
       , headers: {
           'Content-Type': 'application/json; charset=UTF-8'
-        , 'user-agent': `${pkg.name}/${pkg.version}`
         , 'Authorization': /^Basic \w+/
         }
       , qs: {
@@ -135,6 +134,7 @@ test('Logger instance properties', async (t) => {
         userHttps: true
       }
     , [Symbol.for('ignoreRetryableErrors')]: true
+    , sendUserAgent: true
     })
   })
 
@@ -159,6 +159,7 @@ test('Logger instance properties', async (t) => {
     , mac: '01:02:03:04:05:06'
     , tags: ['whiz', 'bang', 'done']
     , ignoreRetryableErrors: false
+    , sendUserAgent: false
     })
     const log = new Logger(apiKey, options)
 
@@ -185,6 +186,7 @@ test('Logger instance properties', async (t) => {
       , timeout: options.timeout
       }
     , [Symbol.for('ignoreRetryableErrors')]: false
+    , sendUserAgent: false
     }
 
     tt.match(log, expected, 'Provided values were used in instantiation')
@@ -196,7 +198,7 @@ test('Logger instance properties', async (t) => {
       UserAgent: transport
     })
     tt.equal(
-      log[Symbol.for('requestDefaults')].headers['user-agent']
+      log[Symbol.for('userAgentHeader')]
     , `${constants.USER_AGENT} (${transport})`
     , 'UserAgent parameter was combined into the user agent header'
     )


### PR DESCRIPTION
When the logger is bundled for browser use, attempting to set the
user-agent can throw a console error of 'Refused to set unsafe header
"user-agent".'  Although the request is still sent, this makes for very
chattery console errors which is undesirable. Since not ALL browsers print
this error, the solution needs to be flexible enough to try and set the
user-agent for most cases, but also allow for it to be turned off. The
`sendUserAgent` constructor option, if set to `false` will omit the
user-agent header.  It is `true` by default.

Semver: minor
Ref: LOG-7793
Fixes: https://github.com/logdna/logger-node/issues/27