### PR TITLE
feat: Add more context (headers) to the errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Logger = require('./lib/logger.js')
 
 let singleton
 
-const setupDefaultLogger = function(key, opts) {
+function setupDefaultLogger(key, opts) {
   if (singleton) return singleton
   singleton = new Logger(key, opts)
   return singleton

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -736,6 +736,7 @@ class Logger extends EventEmitter {
               : error.code // timeouts will populate this
 
             const retrying = ERROR_CODES_TO_RETRY.has(code)
+            const {Authorization: _, ...headers} = config.headers
             const errorMeta = {
               actual: error.message
             , code
@@ -743,6 +744,8 @@ class Logger extends EventEmitter {
             , lastLine
             , retrying
             , attempts: ++this[kAttempts]
+            , headers
+            , url: config.url
             }
 
             if (retrying) {

--- a/package.json
+++ b/package.json
@@ -120,9 +120,9 @@
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.2",
     "eslint": "^7.4.0",
-    "eslint-config-logdna": "^2.0.0",
+    "eslint-config-logdna": "^4.0.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-sensible": "^2.2.0",
+    "eslint-plugin-sensible": "^2.2.1",
     "husky": "^4.2.5",
     "nock": "^13.0.2",
     "tap": "^14.10.8"

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const index = require('../index.js')
 const {apiKey, createOptions} = require('./common/index.js')
 
 test('Index exports are correct', async (t) => {
-  t.equal(Object.keys(index).length, 2, 'property count is correct')
+  t.strictEqual(Object.keys(index).length, 2, 'property count is correct')
   t.match(index, {
     createLogger: Function
   , setupDefaultLogger: Function
@@ -20,8 +20,8 @@ test('setupDefaultLogger', async (t) => {
         app: 'MyDefaultApp'
       })
     )
-    tt.equal(instance.constructor.name, 'Logger', 'Returned an instance')
-    tt.equal(instance.app, 'MyDefaultApp', 'App name is correct')
+    tt.strictEqual(instance.constructor.name, 'Logger', 'Returned an instance')
+    tt.strictEqual(instance.app, 'MyDefaultApp', 'App name is correct')
   })
 
   t.test('Singleton is returned', async (tt) => {
@@ -31,12 +31,12 @@ test('setupDefaultLogger', async (t) => {
         app: 'ThisWillNotWork'
       })
     )
-    tt.equal(instance.constructor.name, 'Logger', 'Returned an instance')
-    tt.equal(instance.app, 'MyDefaultApp', 'App name is correct')
+    tt.strictEqual(instance.constructor.name, 'Logger', 'Returned an instance')
+    tt.strictEqual(instance.app, 'MyDefaultApp', 'App name is correct')
   })
 })
 
 test('createLogger instantiates a Logger instance correctly', async (t) => {
   const log = index.createLogger(apiKey, createOptions())
-  t.equal(log.constructor.name, 'Logger', 'instance returned')
+  t.strictEqual(log.constructor.name, 'Logger', 'instance returned')
 })

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -79,10 +79,10 @@ test('Load test to ensure no data loss and expected payloads', async (t) => {
       // Based on the payload size, and the given instantiation options for
       // buffer size, etc, we can know how many HTTP calls and events we
       // can expect to have happened.
-      tt.equal(linesReceived, TOTAL_LINES, 'Lines sent equals lines received')
-      tt.equal(httpCalls, 19, 'HTTP call count (including errors) is correct')
-      tt.equal(sendEvents, 10, '\'send\' event count does not include errors')
-      tt.equal(errorEvents, 9, 'Expected error count')
+      tt.strictEqual(linesReceived, TOTAL_LINES, 'Lines sent equals lines received')
+      tt.strictEqual(httpCalls, 19, 'HTTP call count (including errors) is correct')
+      tt.strictEqual(sendEvents, 10, '\'send\' event count does not include errors')
+      tt.strictEqual(errorEvents, 9, 'Expected error count')
       logger.removeAllListeners()
       server.close(() => {
         tt.end()

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -59,7 +59,7 @@ test('Load test to ensure no data loss and expected payloads', async (t) => {
 
     logger.on('error', (evt) => {
       errorEvents++
-      tt.deepEqual(evt, {
+      tt.match(evt, {
         name: 'Error'
       , message: 'Temporary connection-based error. It will be retried. '
           + 'See meta data for details.'

--- a/test/logger-agent-log.js
+++ b/test/logger-agent-log.js
@@ -264,7 +264,11 @@ test('Error handling: when gzip fails, raw payload is sent instead', (t) => {
       return true
     })
     .reply(function(uri, requestBody, cb) {
-      t.equal(this.req.headers['Content-Encoding'], undefined, 'Gzip header was removed')
+      t.strictEqual(
+        this.req.headers['Content-Encoding']
+      , undefined
+      , 'Gzip header was removed'
+      )
       cb(null, [200, 'Ingester Success'])
     })
 
@@ -395,7 +399,7 @@ test('.agentLog() payload format handles 207 responses and emits errors', (t) =>
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls
-      t.equal(payload.length, 4, 'Payload has the right number of entries')
+      t.strictEqual(payload.length, 4, 'Payload has the right number of entries')
       t.match(payload, [
         {line: lines[0]}
       , {line: lines[1]}

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -49,7 +49,7 @@ test('timestamp validity checks', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls
-      t.equal(payload.length, 2, 'Number of lines is correct')
+      t.strictEqual(payload.length, 2, 'Number of lines is correct')
       const [{timestamp: stamp1}, {timestamp: stamp2}] = payload
       t.ok(stamp1 > startTime, 'bad time format was replaced with a good one')
       t.ok(stamp2 > startTime, 'out of range time was replaced with a good one')
@@ -126,7 +126,7 @@ test('.log() passed an invalid log level uses the default instead', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const obj = body.ls[0]
-      t.equal(obj.level, 'INFO', 'Default level was used instead')
+      t.strictEqual(obj.level, 'INFO', 'Default level was used instead')
       return true
     })
     .query(() => { return true })
@@ -221,7 +221,7 @@ test('HTTP timeout will emit Error and continue to retry', (t) => {
   // the same as a timeout on response body (connection accepted; no reply)
   nock(logger.url)
     .post('/', () => {
-      t.equal(
+      t.strictEqual(
         logger[Symbol.for('isLoggingBackedOff')]
       , false
       , 'Logger is not backed off prior to the first failure'
@@ -232,7 +232,7 @@ test('HTTP timeout will emit Error and continue to retry', (t) => {
     .delayConnection(delay + 1)
     .reply(200, 'Will Not Happen')
     .post('/', () => {
-      t.equal(
+      t.strictEqual(
         logger[Symbol.for('isLoggingBackedOff')]
       , true
       , 'Logger is backed off'
@@ -267,8 +267,8 @@ test('HTTP timeout will emit Error and continue to retry', (t) => {
   })
 
   logger.on('cleared', ({message}) => {
-    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
-    t.equal(
+    t.strictEqual(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.strictEqual(
       logger[Symbol.for('isLoggingBackedOff')]
     , false
     , 'Logger is not backed off after having a successful connection'
@@ -308,7 +308,7 @@ test('A 500-level statusCode error will continue to retry', (t) => {
       // Fail 3 times, then succeed
       nock(logger.url)
         .post('/', () => {
-          tt.equal(
+          tt.strictEqual(
             logger[Symbol.for('isLoggingBackedOff')]
           , false
           , 'Logger is not backed off prior to the first failure'
@@ -318,7 +318,7 @@ test('A 500-level statusCode error will continue to retry', (t) => {
         .query(() => { return true })
         .reply(code, 'SERVER KABOOM')
         .post('/', () => {
-          tt.equal(
+          tt.strictEqual(
             logger[Symbol.for('isLoggingBackedOff')]
           , true
           , 'Logger is backed off'
@@ -350,8 +350,12 @@ test('A 500-level statusCode error will continue to retry', (t) => {
       })
 
       logger.on('cleared', ({message}) => {
-        tt.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
-        tt.equal(
+        tt.strictEqual(
+          message
+        , 'All accumulated log entries have been sent'
+        , 'cleared msg'
+        )
+        tt.strictEqual(
           logger[Symbol.for('isLoggingBackedOff')]
         , false
         , 'Logger is not backed off after having a successful connection'
@@ -395,7 +399,7 @@ test('Connection-based error codes trigger a retry', (t) => {
       // Fail 3 times, then succeed
       nock(logger.url)
         .post('/', () => {
-          tt.equal(
+          tt.strictEqual(
             logger[Symbol.for('isLoggingBackedOff')]
           , false
           , 'Logger is not backed off prior to the first failure'
@@ -405,7 +409,7 @@ test('Connection-based error codes trigger a retry', (t) => {
         .query(() => { return true })
         .replyWithError({code})
         .post('/', () => {
-          tt.equal(
+          tt.strictEqual(
             logger[Symbol.for('isLoggingBackedOff')]
           , true
           , 'Logger is backed off'
@@ -437,8 +441,12 @@ test('Connection-based error codes trigger a retry', (t) => {
       })
 
       logger.on('cleared', ({message}) => {
-        tt.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
-        tt.equal(
+        tt.strictEqual(
+          message
+        , 'All accumulated log entries have been sent'
+        , 'cleared msg'
+        )
+        tt.strictEqual(
           logger[Symbol.for('isLoggingBackedOff')]
         , false
         , 'Logger is not backed off after having a successful connection'
@@ -464,7 +472,7 @@ test('User-level errors are discarded after emitting an error', (t) => {
 
   nock(logger.url)
     .post('/', () => {
-      t.equal(
+      t.strictEqual(
         logger[Symbol.for('isLoggingBackedOff')]
       , false
       , 'User errors did not cause logger to back off'
@@ -493,9 +501,9 @@ test('User-level errors are discarded after emitting an error', (t) => {
   })
 
   logger.on('cleared', ({message}) => {
-    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
-    t.equal(logger[Symbol.for('isSending')], false, 'no longer sending')
-    t.equal(logger[Symbol.for('totalLinesReady')], 0, 'no more lines ready')
+    t.strictEqual(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.strictEqual(logger[Symbol.for('isSending')], false, 'no longer sending')
+    t.strictEqual(logger[Symbol.for('totalLinesReady')], 0, 'no more lines ready')
     t.deepEqual(logger[Symbol.for('readyToSend')], [], 'send buffer is empty')
   })
 
@@ -550,7 +558,7 @@ test('Retry-able errors are not emitted by default', (t) => {
   })
 
   logger.on('cleared', ({message}) => {
-    t.equal(message, 'All accumulated log entries have been sent', 'cleared msg')
+    t.strictEqual(message, 'All accumulated log entries have been sent', 'cleared msg')
     t.end()
   })
   logger.log('This is a retryable error, but the event will NOT be emitted')

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -8,10 +8,10 @@ const {apiKey, createOptions} = require('./common/index.js')
 
 test('Exports structure', async (t) => {
   t.type(Logger, Function, 'Logger is a function')
-  t.equal(Logger.name, 'Logger', 'Class name is correct')
+  t.strictEqual(Logger.name, 'Logger', 'Class name is correct')
 
   const methods = Object.getOwnPropertyNames(Logger.prototype)
-  t.equal(methods.length, 15, 'Logger.prototype prop count')
+  t.strictEqual(methods.length, 15, 'Logger.prototype prop count')
   t.deepEqual(methods, [
     'constructor'
   , 'addMetaProperty'
@@ -33,7 +33,7 @@ test('Exports structure', async (t) => {
 
 test('Logger instantiation', async (t) => {
   const log = new Logger(apiKey, createOptions())
-  t.equal(log.constructor.name, 'Logger', 'instance returned')
+  t.strictEqual(log.constructor.name, 'Logger', 'instance returned')
 })
 
 test('Logger instance properties', async (t) => {
@@ -88,7 +88,11 @@ test('Logger instance properties', async (t) => {
       })
       const agent = logger[Symbol.for('requestDefaults')].agent
       const constructorName = Object.getPrototypeOf(agent).constructor.name
-      ttt.equal(constructorName, 'HttpsAgent', 'The agent is agentkeepalive.HttpsAgent')
+      ttt.strictEqual(
+        constructorName
+      , 'HttpsAgent'
+      , 'The agent is agentkeepalive.HttpsAgent'
+      )
     })
 
     tt.test('No proxy: http url is used (buyer beware!)', async (ttt) => {
@@ -97,7 +101,7 @@ test('Logger instance properties', async (t) => {
       })
       const agent = logger[Symbol.for('requestDefaults')].agent
       const constructorName = Object.getPrototypeOf(agent).constructor.name
-      ttt.equal(constructorName, 'Agent', 'The agent is agentkeepalive.Agent')
+      ttt.strictEqual(constructorName, 'Agent', 'The agent is agentkeepalive.Agent')
     })
 
     tt.test('Insecure Proxy used: Agent should be HttpsProxyAgent', async (ttt) => {
@@ -106,7 +110,7 @@ test('Logger instance properties', async (t) => {
       })
       const agent = logger[Symbol.for('requestDefaults')].agent
       const constructorName = Object.getPrototypeOf(agent).constructor.name
-      ttt.equal(constructorName, 'HttpsProxyAgent', 'The agent is HttpsProxyAgent')
+      ttt.strictEqual(constructorName, 'HttpsProxyAgent', 'The agent is HttpsProxyAgent')
     })
 
     tt.test('Secure Proxy used: Agent should be HttpsProxyAgent', async (ttt) => {
@@ -115,7 +119,7 @@ test('Logger instance properties', async (t) => {
       })
       const agent = logger[Symbol.for('requestDefaults')].agent
       const constructorName = Object.getPrototypeOf(agent).constructor.name
-      ttt.equal(constructorName, 'HttpsProxyAgent', 'The agent is HttpsProxyAgent')
+      ttt.strictEqual(constructorName, 'HttpsProxyAgent', 'The agent is HttpsProxyAgent')
     })
   })
 
@@ -197,7 +201,7 @@ test('Logger instance properties', async (t) => {
     const log = new Logger(apiKey, {
       UserAgent: transport
     })
-    tt.equal(
+    tt.strictEqual(
       log[Symbol.for('userAgentHeader')]
     , `${constants.USER_AGENT} (${transport})`
     , 'UserAgent parameter was combined into the user agent header'
@@ -210,7 +214,7 @@ test('Logger instance properties', async (t) => {
     })
     const expected = 'one,two,three'
     const log = new Logger(apiKey, options)
-    tt.equal(
+    tt.strictEqual(
       log[Symbol.for('requestDefaults')].qs.tags
     , expected
     , 'Tag string was parsed correctly and set'
@@ -223,7 +227,7 @@ test('Logger instance properties', async (t) => {
     })
     const expected = 'one,two,three'
     const log = new Logger(apiKey, options)
-    tt.equal(
+    tt.strictEqual(
       log[Symbol.for('requestDefaults')].qs.tags
     , expected
     , 'Tags array was parsed correctly and set'
@@ -236,21 +240,21 @@ test('Deprecated fields are still allowed and re-assigned', async (t) => {
     const log = new Logger(apiKey, {
       logdna_url: 'http://myhost'
     })
-    tt.equal(log.url, 'http://myhost', 'url was set instead')
+    tt.strictEqual(log.url, 'http://myhost', 'url was set instead')
   })
 
   t.test('index_meta is re-assigned to indexMeta', async (tt) => {
     const log = new Logger(apiKey, {
       index_meta: true
     })
-    tt.equal(log.indexMeta, true, 'indexMeta was set instead')
+    tt.strictEqual(log.indexMeta, true, 'indexMeta was set instead')
   })
 
   t.test('with_credentails is re-assigned to withCredentials', async (tt) => {
     const log = new Logger(apiKey, {
       with_credentials: true
     })
-    tt.equal(
+    tt.strictEqual(
       log[Symbol.for('requestDefaults')].withCredentials
     , true
     , 'withCredentials was set instead'

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -32,7 +32,7 @@ test('Test all log levels, including send events', async (t) => {
       const scope = nock(opts.url)
         .post('/', (body) => {
           const numProps = Object.keys(body).length
-          tt.equal(numProps, 2, 'Number of request body properties')
+          tt.strictEqual(numProps, 2, 'Number of request body properties')
           tt.match(body, {
             e: 'ls'
           , ls: [
@@ -45,7 +45,7 @@ test('Test all log levels, including send events', async (t) => {
               }
             ]
           })
-          tt.equal(body.ls.length, 1, 'log line count')
+          tt.strictEqual(body.ls.length, 1, 'log line count')
           return true
         })
         .query((qs) => {
@@ -93,7 +93,7 @@ test('Using an https:// url sends and https agent', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.line, 'This is over HTTPS', 'Log text was passed in body')
+      t.strictEqual(payload.line, 'This is over HTTPS', 'Log text was passed in body')
       return true
     })
     .query(() => { return true })
@@ -123,8 +123,8 @@ test('log() can be called by itself without using a level shortcut', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.line, 'Hi there', 'Log text was passed in body')
-      t.equal(payload.level, 'INFO', 'Default level was used')
+      t.strictEqual(payload.line, 'Hi there', 'Log text was passed in body')
+      t.strictEqual(payload.level, 'INFO', 'Default level was used')
       return true
     })
     .query((qs) => {
@@ -196,7 +196,7 @@ test('log() can be passed an object to log, and serialization is "safe"', (t) =>
   nock(logger.url)
     .post('/', (body) => {
       const line = body.ls[0].line
-      t.equal(line, expected, 'Object was serialized safely')
+      t.strictEqual(line, expected, 'Object was serialized safely')
       return true
     })
     .query(() => { return true })
@@ -227,7 +227,7 @@ test('log() can be called with level (case insensitive) as an opts string', (t) 
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.level, 'DEBUG', 'Level is correct')
+      t.strictEqual(payload.level, 'DEBUG', 'Level is correct')
       return true
     })
     .query(() => { return true })
@@ -327,7 +327,7 @@ test('Using global meta in combination with per-message meta', (t) => {
       , two: 'TWO'
       , three: 3
       }
-      t.equal(
+      t.strictEqual(
         payload.meta
       , JSON.stringify(expectedMeta)
       , 'per-message meta was merged with global meta'
@@ -366,7 +366,7 @@ test('Using opts.context will replace opts.meta', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.meta, JSON.stringify(opts.context), 'Context replaced meta')
+      t.strictEqual(payload.meta, JSON.stringify(opts.context), 'Context replaced meta')
       return true
     })
     .query(() => { return true })
@@ -400,7 +400,7 @@ test('opts.context is ignored when it\'s not an object', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.meta, JSON.stringify({inMeta: true}), 'Context ignored')
+      t.strictEqual(payload.meta, JSON.stringify({inMeta: true}), 'Context ignored')
       return true
     })
     .query(() => { return true })
@@ -640,7 +640,7 @@ test('addMetaProperty() adds it to each message; indexMeta: false', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(
+      t.strictEqual(
         payload.meta
       , '{"metaProp":"metaVal"}'
       , 'meta property injected into message payload'
@@ -736,7 +736,7 @@ test('removeMetaProperty() removes it from the payload; indexMeta: false', (t) =
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.meta
+      t.strictEqual(payload.meta
       , '{"one":1,"three":3}'
       , 'meta property was removed from the message payload'
       )
@@ -764,7 +764,7 @@ test('Can call .log with HTTP (not https)', (t) => {
   const logger = new Logger(apiKey, createOptions({
     url: 'http://localhost:12345'
   }))
-  t.equal(logger[Symbol.for('requestDefaults')].useHttps, false, 'HTTPS is off')
+  t.strictEqual(logger[Symbol.for('requestDefaults')].useHttps, false, 'HTTPS is off')
   t.on('end', async () => {
     nock.cleanAll()
   })
@@ -800,7 +800,7 @@ test('Flushing on a timer includes multiple lines', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls
-      t.equal(payload.length, 3, 'Payload has the right number of entries')
+      t.strictEqual(payload.length, 3, 'Payload has the right number of entries')
       t.match(payload, [
         {
           timestamp: Number
@@ -914,7 +914,7 @@ test('flush() can be called any time, and always emits \'cleared\'', (t) => {
   const logger = new Logger(apiKey, createOptions())
 
   logger.on('cleared', ({message}) => {
-    t.equal(message, 'All buffers clear; Nothing to send', 'Got cleared event')
+    t.strictEqual(message, 'All buffers clear; Nothing to send', 'Got cleared event')
   })
 
   logger.flush()
@@ -942,7 +942,7 @@ test('207 partial-success responses emit errors for the failed lines', (t) => {
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls
-      t.equal(payload.length, 4, 'Payload has the right number of entries')
+      t.strictEqual(payload.length, 4, 'Payload has the right number of entries')
       t.match(payload, [
         {line: lines[0]}
       , {line: lines[1]}
@@ -1127,7 +1127,7 @@ test('sendUserAgent is `true` by default. Custom user-agent is sent.', (t) => {
     })
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.line, line)
+      t.strictEqual(payload.line, line)
       return true
     })
     .query(() => { return true })
@@ -1159,7 +1159,7 @@ test('sendUserAgent is `false`. Logger client\'s user-agent value is NOT sent', 
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.line, line)
+      t.strictEqual(payload.line, line)
       return true
     })
     .query(() => { return true })

--- a/test/unit/lang/type-of.js
+++ b/test/unit/lang/type-of.js
@@ -62,7 +62,7 @@ test('typeOf', (t) => {
     }
   ]
   for (const current of cases) {
-    t.equal(
+    t.strictEqual(
       typeOf(current.value)
     , current.expected
     , current.message || `typeOf(${current.value}) == ${current.expected}`


### PR DESCRIPTION
**feat: Add more context (headers) to the errors**

In some cases, HTTP errors can happen with things
like invalid header values. In order to properly debug
such situations, we need to report as much context
about the connection that we safely can. Part of this
will be exposing the header values. The URL of the
connection has also been requested in the past, and so
that has also been added to the error's metadata.

Semver: minor
Fixes: https://github.com/logdna/logger-node/issues/34

---

**deps: eslint-config-logdna@4.0.2**

Bump the eslint (and sensible) dependencies.

Semver: patch