### PR TITLE
Darinspivey/issue37

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,8 +18,6 @@ module.exports = {
 , LOG_LEVELS: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']
 , LOGDNA_URL: 'https://logs.logdna.com/logs/ingest'
 , MAC_ADDR_CHECK: /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
-, MAX_INPUT_LENGTH: 80
-, MAX_LINE_LENGTH: 32000
 , MAX_REQUEST_TIMEOUT: 300000
 , MS_IN_A_DAY: 86400000
 , PAYLOAD_STRUCTURES: {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -126,8 +126,11 @@ class Logger extends EventEmitter {
         throw err
       }
       tags = tags
-        .filter((tag) => { return tag !== '' })
-        .map((tag) => { return tag.trim() })
+        .map((tag) => {
+          if (tag === null || tag === undefined) return null
+          return String(tag).trim()
+        })
+        .filter(Boolean)
         .join(',')
     }
 

--- a/lib/validators/check-string-param.js
+++ b/lib/validators/check-string-param.js
@@ -1,14 +1,7 @@
 'use strict'
 
-const constants = require('../constants.js')
-
 module.exports = function checkStringParam(param, name) {
   if (!param || typeof param !== 'string') {
     throw new TypeError(`${name} is undefined or not passed as a String`)
-  }
-  if (param.length > constants.MAX_INPUT_LENGTH) {
-    throw new TypeError(
-      `${name} cannot be longer than ${constants.MAX_INPUT_LENGTH} chars`
-    )
   }
 }

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -125,6 +125,19 @@ test('Logger instance properties', async (t) => {
 
   t.test('Check default property values of properties', async (tt) => {
     const log = new Logger(apiKey)
+
+    tt.match(
+      log[Symbol.for('requestDefaults')].useHttps
+    , true
+    , 'useHttps is true'
+    )
+
+    tt.strictEqual(
+      log[Symbol.for('ignoreRetryableErrors')]
+    , true
+    , 'ignoreRetryableErrors is true'
+    )
+
     tt.match(log, {
       flushLimit: 5000000
     , flushIntervalMs: 250
@@ -134,10 +147,6 @@ test('Logger instance properties', async (t) => {
     , url: 'https://logs.logdna.com/logs/ingest'
     , app: 'default'
     , level: 'INFO'
-    , [Symbol.for('requestDefaults')]: {
-        userHttps: true
-      }
-    , [Symbol.for('ignoreRetryableErrors')]: true
     , sendUserAgent: true
     })
   })

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -522,30 +522,6 @@ test('Instantiation Errors', async (t) => {
     }, 'Expected error thrown')
   })
 
-  t.test('app name is too long', async (tt) => {
-    const app = 'x'.repeat(constants.MAX_INPUT_LENGTH) + 1
-    tt.throws(() => {
-      return new Logger(apiKey, {
-        app
-      })
-    }, {
-      message: 'app cannot be longer than 80 chars'
-    , name: 'TypeError'
-    }, 'Expected error thrown')
-  })
-
-  t.test('env name is too long', async (tt) => {
-    const env = 'x'.repeat(constants.MAX_INPUT_LENGTH) + 1
-    tt.throws(() => {
-      return new Logger(apiKey, {
-        env
-      })
-    }, {
-      message: 'env cannot be longer than 80 chars'
-    , name: 'TypeError'
-    }, 'Expected error thrown')
-  })
-
   t.test('Bad payloadStructure', async (tt) => {
     tt.throws(() => {
       return new Logger(apiKey, {

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -161,7 +161,7 @@ test('Logger instance properties', async (t) => {
     , meta: {hey: 'there'}
     , hostname: 'bleck'
     , mac: '01:02:03:04:05:06'
-    , tags: ['whiz', 'bang', 'done']
+    , tags: ['whiz', null, undefined, '', ' ', '\t', '\n', 'bang', 'done', 1234, 0]
     , ignoreRetryableErrors: false
     , sendUserAgent: false
     })
@@ -178,22 +178,29 @@ test('Logger instance properties', async (t) => {
     , env: options.env
     , app: options.app
     , url: options.url
-    , [Symbol.for('requestDefaults')]: {
-        withCredentials: options.withCredentials
-      , useHttps: false
-      , qs: {
-          hostname: options.hostname
-        , mac: options.mac
-        , ip: ipv6
-        , tags: options.tags
-        }
-      , timeout: options.timeout
-      }
-    , [Symbol.for('ignoreRetryableErrors')]: false
     , sendUserAgent: false
     }
 
     tt.match(log, expected, 'Provided values were used in instantiation')
+
+    const requestDefaults = log[Symbol.for('requestDefaults')]
+    tt.match(requestDefaults, {
+      withCredentials: options.withCredentials
+    , useHttps: false
+    , qs: {
+        hostname: options.hostname
+      , mac: options.mac
+      , ip: ipv6
+      , tags: 'whiz,bang,done,1234,0'
+      }
+    , timeout: options.timeout
+    }, 'requestDefaults are correct')
+
+    tt.strictEqual(
+      log[Symbol.for('ignoreRetryableErrors')]
+    , false
+    , 'ignoreRetryableErrors was set correctly'
+    )
   })
 
   t.test('UserAgent passed from a transport is included', async (tt) => {


### PR DESCRIPTION
This change removes any validation that would throw errors on instantiation.  The server enforces these limits, and although doing so at the client can stop unnecessary traffic, it needs to be all-or-nothing, and be done correctly.  The limit enforced here for the `hostname` was incorrect, and we do not enforce other limits such as `tags` and `metadata`.

Along the way, a few minor bugs were discovered and fixed:
* A non-string tag type provided in an array of tags would throw
* `t.match` assertions do not work on `Symbol()` properties as part of a larger object