### PR TITLE
fix: Remove invalid characters from the user-agent

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@ module.exports = {
 , MAC_ADDR_CHECK: /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
 , MAX_REQUEST_TIMEOUT: 300000
 , MS_IN_A_DAY: 86400000
+, NON_PRINTABLE_CHAR_RE: /[^\x20-\x7E]/g
 , PAYLOAD_STRUCTURES: {
     AGENT: 'agent'
   , DEFAULT: 'default'

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -346,7 +346,10 @@ class Logger extends EventEmitter {
       agent = new HttpsProxyAgent(options.proxy)
     }
 
-    this[kUserAgentHeader] = `${constants.USER_AGENT}${transportedBy}`
+    this[kUserAgentHeader] = `${constants.USER_AGENT}${transportedBy}`.replace(
+      constants.NON_PRINTABLE_CHAR_RE
+    , ''
+    )
 
     this[kRequestDefaults] = {
       auth: {username: key}

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -224,6 +224,18 @@ test('Logger instance properties', async (t) => {
     )
   })
 
+  t.test('UserAgent is stripped of invalid characters', async (tt) => {
+    const log = new Logger(apiKey, {
+      UserAgent: '\n\nlogdna-w\0inson/2.3.2\0\n'
+    })
+    const expected = `${constants.USER_AGENT} (logdna-winson/2.3.2)`
+    tt.strictEqual(
+      log[Symbol.for('userAgentHeader')]
+    , expected
+    , 'UserAgent value contains only valid characters'
+    )
+  })
+
   t.test('Tags can be a string', async (tt) => {
     const options = createOptions({
       tags: 'one ,  two,   three  '


### PR DESCRIPTION
Part of the user-agent header value can be passed in
during instantiation. This value should be stripped
of all characters that would be considered invalid and
thus cause an HTTP header error. Such characters are
newlines and the like, so for our purposes, we will
strip all non-printable characters from the user-agent
value.

Semver: patch
Fixes: https://github.com/logdna/logger-node/issues/34