### PR TITLE
feat: Add EADDRNOTAVAIL to the retryable error codes

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -56,6 +56,7 @@ const ERROR_CODES_TO_RETRY = new Set([
 , 'EPIPE'
 , 'ENOTFOUND'
 , 'ENETUNREACH'
+, 'EADDRNOTAVAIL'
 ])
 
 class Logger extends EventEmitter {

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -404,6 +404,7 @@ test('Connection-based error codes trigger a retry', (t) => {
   , 'EPIPE'
   , 'ENOTFOUND'
   , 'ENETUNREACH'
+  , 'EADDRNOTAVAIL'
   ]
 
   codes.forEach((code) => {


### PR DESCRIPTION
This error code can be thrown due to a disconnected
network connection. It should certainly be a retryable
error.

Semver: minor
Fixes: https://github.com/logdna/logger-node/issues/40