### PR TITLE
fix: Turn off maxBodyLength in Axios

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -650,6 +650,7 @@ class Logger extends EventEmitter {
     , json: true
     , httpsAgent: undefined
     , httpAgent: undefined
+    , maxBodyLength: Infinity
     }
 
     // Setting this to `false` can avoid the browser console error of:


### PR DESCRIPTION
Axios has a maxBodyLength which defaults to
2000 bytes. Given that the payloads for the
logger can be much larger than this, turn this
limitation off. It should be noted that there's
only 1 report of this in the wild, and the problem
has not been able to be reproduced.

Semver: patch
Fixes: https://github.com/logdna/logger-node/issues/44