### PR TITLE
fix(docs): Correct bad documentation for logging errors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -49,6 +49,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mdeltito",
+      "name": "Mike Del Tito",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69520?v=4",
+      "profile": "https://github.com/mdeltito",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -22,6 +22,15 @@
         "test",
         "ideas"
       ]
+    },
+    {
+      "login": "relative",
+      "name": "relative",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59253100?v=4",
+      "profile": "https://pxl.blue/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -58,6 +58,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "nhuttm",
+      "name": "Nhut Tran",
+      "avatar_url": "https://avatars.githubusercontent.com/u/51075198?v=4",
+      "profile": "https://www.designveloper.com/vi/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -31,6 +31,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ligerzero459",
+      "name": "Ryan Mottley",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1093351?v=4",
+      "profile": "https://github.com/ligerzero459",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -40,6 +40,15 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "alanzchen",
+      "name": "Alan Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2144783?v=4",
+      "profile": "https://github.com/alanzchen",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -67,6 +67,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "esatterwhite",
+      "name": "Eric Satterwhite",
+      "avatar_url": "https://avatars.githubusercontent.com/u/148561?v=4",
+      "profile": "http://codedependant.net/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,28 @@
+{
+  "projectName": "logger-node",
+  "projectOwner": "logdna",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "darinspivey",
+      "name": "Darin Spivey",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1874788?v=4",
+      "profile": "https://github.com/darinspivey",
+      "contributions": [
+        "code",
+        "doc",
+        "maintenance",
+        "test",
+        "ideas"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 <p align="center">
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
   </a>
@@ -589,3 +592,23 @@ Copyright © [LogDNA](https://logdna.com), released under an MIT license. See th
 [`<TypeError>`]: https://mdn.io/TypeError
 [`<RangeError>`]: https://mdn.io/RangeError
 [`<Error>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Documentation">📖</a> <a href="#maintenance-darinspivey" title="Maintenance">🚧</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Tests">⚠️</a> <a href="#ideas-darinspivey" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
@@ -607,6 +607,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/ligerzero459"><img src="https://avatars.githubusercontent.com/u/1093351?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Mottley</b></sub></a><br /><a href="#maintenance-ligerzero459" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/alanzchen"><img src="https://avatars.githubusercontent.com/u/2144783?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Chen</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=alanzchen" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/mdeltito"><img src="https://avatars.githubusercontent.com/u/69520?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Del Tito</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=mdeltito" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://www.designveloper.com/vi/"><img src="https://avatars.githubusercontent.com/u/51075198?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nhut Tran</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=nhuttm" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
@@ -606,6 +606,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://pxl.blue/"><img src="https://avatars.githubusercontent.com/u/59253100?v=4?s=100" width="100px;" alt=""/><br /><sub><b>relative</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=relative" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/ligerzero459"><img src="https://avatars.githubusercontent.com/u/1093351?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Mottley</b></sub></a><br /><a href="#maintenance-ligerzero459" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/alanzchen"><img src="https://avatars.githubusercontent.com/u/2144783?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Chen</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=alanzchen" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/mdeltito"><img src="https://avatars.githubusercontent.com/u/69520?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Del Tito</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=mdeltito" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
@@ -605,6 +605,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Documentation">📖</a> <a href="#maintenance-darinspivey" title="Maintenance">🚧</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Tests">⚠️</a> <a href="#ideas-darinspivey" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://pxl.blue/"><img src="https://avatars.githubusercontent.com/u/59253100?v=4?s=100" width="100px;" alt=""/><br /><sub><b>relative</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=relative" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/ligerzero459"><img src="https://avatars.githubusercontent.com/u/1093351?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Mottley</b></sub></a><br /><a href="#maintenance-ligerzero459" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/alanzchen"><img src="https://avatars.githubusercontent.com/u/2144783?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Chen</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=alanzchen" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 <p align="center">
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
   </a>
@@ -608,6 +605,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/alanzchen"><img src="https://avatars.githubusercontent.com/u/2144783?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Chen</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=alanzchen" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/mdeltito"><img src="https://avatars.githubusercontent.com/u/69520?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Del Tito</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=mdeltito" title="Documentation">📖</a></td>
     <td align="center"><a href="https://www.designveloper.com/vi/"><img src="https://avatars.githubusercontent.com/u/51075198?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nhut Tran</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=nhuttm" title="Code">💻</a></td>
+    <td align="center"><a href="http://codedependant.net/"><img src="https://avatars.githubusercontent.com/u/148561?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eric Satterwhite</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=esatterwhite" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
@@ -604,6 +604,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Documentation">📖</a> <a href="#maintenance-darinspivey" title="Maintenance">🚧</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Tests">⚠️</a> <a href="#ideas-darinspivey" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://pxl.blue/"><img src="https://avatars.githubusercontent.com/u/59253100?v=4?s=100" width="100px;" alt=""/><br /><sub><b>relative</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=relative" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ligerzero459"><img src="https://avatars.githubusercontent.com/u/1093351?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Mottley</b></sub></a><br /><a href="#maintenance-ligerzero459" title="Maintenance">🚧</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   <a href="https://app.logdna.com">
     <img height="95" width="201" src="https://raw.githubusercontent.com/logdna/artwork/master/logo%2Bnode.png">
@@ -603,6 +603,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Documentation">📖</a> <a href="#maintenance-darinspivey" title="Maintenance">🚧</a> <a href="https://github.com/logdna/logger-node/commits?author=darinspivey" title="Tests">⚠️</a> <a href="#ideas-darinspivey" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://pxl.blue/"><img src="https://avatars.githubusercontent.com/u/59253100?v=4?s=100" width="100px;" alt=""/><br /><sub><b>relative</b></sub></a><br /><a href="https://github.com/logdna/logger-node/commits?author=relative" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -41,36 +41,6 @@
     "name": "LogDNA, Inc.",
     "email": "help@logdna.com"
   },
-  "contributors": [
-    {
-      "name": "Alan Chen",
-      "email": "github@zenan.ch"
-    },
-    {
-      "name": "Darin Spivey",
-      "email": "darin.spivey@logdna.com"
-    },
-    {
-      "name": "Eric Satterwhite",
-      "email": "esatterwhite@wi.rr.com"
-    },
-    {
-      "name": "Mike Del Tito",
-      "email": "mike.deltito@logdna.com"
-    },
-    {
-      "name": "Ryan Mottley",
-      "email": "ryan.mottley@logdna.com"
-    },
-    {
-      "name": "relative",
-      "email": "relative@riseup.net"
-    },
-    {
-      "name": "Tran Minh Nhut",
-      "email": "nhuttm@dgroup.co"
-    }
-  ],
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/logdna/logger-node/issues"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,16 @@
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run lint",
-    "test": "tap"
+    "test": "tap",
+    "pretest:ci": "npm run lint",
+    "test:ci": "tools/test-ci.sh",
+    "release": "semantic-release"
+  },
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "extends": "semantic-release-config-logdna"
   },
   "repository": {
     "type": "git",
@@ -80,63 +89,6 @@
       "ecmaVersion": 2019
     }
   },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
-  "commitlint": {
-    "rules": {
-      "body-leading-blank": [
-        2,
-        "always"
-      ],
-      "body-max-line-length": [
-        2,
-        "always",
-        72
-      ],
-      "body-min-length": [
-        2,
-        "always",
-        20
-      ],
-      "subject-max-length": [
-        2,
-        "always",
-        72
-      ],
-      "scope-empty": [
-        2,
-        "always"
-      ],
-      "subject-full-stop": [
-        2,
-        "never",
-        "."
-      ],
-      "type-enum": [
-        2,
-        "always",
-        [
-          "feat",
-          "deps",
-          "fix",
-          "docs",
-          "package",
-          "style",
-          "refactor",
-          "test",
-          "revert",
-          "WIP"
-        ]
-      ],
-      "type-empty": [
-        2,
-        "never"
-      ]
-    }
-  },
   "publishConfig": {
     "access": "public"
   },
@@ -153,8 +105,11 @@
     "eslint-config-logdna": "^4.0.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-sensible": "^2.2.1",
-    "husky": "^4.2.5",
     "nock": "^13.0.2",
-    "tap": "^14.10.8"
+    "semantic-release": "^17.4.2",
+    "semantic-release-config-logdna": "^1.1.1",
+    "tap": "^14.11.0",
+    "tap-parser": "^10.1.0",
+    "tap-xunit": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,8 +103,6 @@
     "@commitlint/config-conventional": "^9.1.2",
     "eslint": "^7.4.0",
     "eslint-config-logdna": "^4.0.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-sensible": "^2.2.1",
     "nock": "^13.0.2",
     "semantic-release": "^17.4.2",
     "semantic-release-config-logdna": "^1.1.1",

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+mkdir -p coverage
+tap
+
+code=$?
+cat .tap-output | ./node_modules/.bin/tap-parser -t -f | ./node_modules/.bin/tap-xunit > coverage/test.xml
+exit $code


### PR DESCRIPTION
**fix(docs): Correct bad documentation for logging errors**

`Error` objects are largely non-enumerable, so they
don't serialize well. Improve the docuementation for
how to properly log errors.

Semver: patch
Fixes: https://github.com/logdna/logger-node/issues/48

---

**docs: add @esatterwhite as a contributor**

---

**docs: add @nhuttm as a contributor**

---

**docs: add @mdeltito as a contributor**

---

**docs: add @alanzchen as a contributor**

---

**docs: add @ligerzero459 as a contributor**

---

**chore(contributors): Use all-contributors**

This removes the hardcoded `contributors` list in
package.json and moves to the common `all-contributors`
package to list contributors in the README.

---

**docs: add @relative as a contributor**

---

**docs: add @darinspivey as a contributor**

---

**chore(deps): Remove unnecessary eslint plugins**

These plugins are part of `eslint-config-logdna` and
thus do not need to explicitly be installed.

---

**ci: Switch to using semantic-release**

This changes to semantic-release for package deployment
and semantic versioning. This also removes the use
of Husky because it doesn't really work well for enforcing
commit message formatting. In the future, we will add
`commitlint` to `semantic-release-config-logdna`.

Semver: patch
