### PR TITLE
handle the situation when option property is falsy

### DIFF
--- a/lib/validators/has.js
+++ b/lib/validators/has.js
@@ -6,7 +6,7 @@
 module.exports = function has(obj, prop) {
   const exists = Object.prototype.hasOwnProperty.call(obj, prop)
   if (!exists) return false
-  if (obj[prop] === undefined || obj[prop] === null || obj[prop]==="") return false
+  if (obj[prop] === undefined || obj[prop] === null || obj[prop]==='') return false
 
   return true
 }

--- a/lib/validators/has.js
+++ b/lib/validators/has.js
@@ -6,7 +6,7 @@
 module.exports = function has(obj, prop) {
   const exists = Object.prototype.hasOwnProperty.call(obj, prop)
   if (!exists) return false
-  if (obj[prop] === undefined || obj[prop] === null) return false
+  if (obj[prop] === undefined || obj[prop] === null || obj[prop]==="") return false
 
   return true
 }


### PR DESCRIPTION
When one of the properties of option is "" , has property returns true but it fails on typeOf check for it to be string. 
eg. value for env key is '', earlier has property returned true and it failed on checkStringParam. '' is string and should not have failed. So adding extra check for empty string on hasProperty function would help resolve this descrepency