### PR TITLE
fix(package): Include missing files and type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "files": [
     "lib/",
+    "docs/",
     "index.js",
+    "types.d.ts",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"


### PR DESCRIPTION
The last update changed to using an npm `files` whitelist
in order to keep the package size down. The typescript
definitions file and the docs directory were left out.

Fixes: #55