### PR TITLE
feat(max-attempts): support retry limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ For those cases, additional properties (apart from `message`) are included:
     * `env` [`<String>`][] - An environment label attached to each message
     * `baseBackoffMs` [`<Number>`][] - Minimum exponential backoff time in milliseconds. **Default:** `3000`ms
     * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
+    * `maxAttempts` [`<Number>`][] - Maximum number of times the logger will try to send a buffer of messages when retryable errors are encountered; when the limit is reached, retryable errors will be treated as non-retryable errors.  **Default:** `-1`, meaning unlimited.
     * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,7 @@ module.exports = {
   AGENT_SETTING: {maxSockets: 20, freeSocketTimeout: 60000}
 , BASE_BACKOFF_MILLIS: 3000
 , MAX_BACKOFF_MILLIS: 30000
+, MAX_ATTEMPS: -1
 , DEFAULT_REQUEST_TIMEOUT: 30000
 , USER_AGENT: `${pkg.name}/${pkg.version}`
 , FLUSH_BYTE_LIMIT: 5000000

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,7 @@ module.exports = {
   AGENT_SETTING: {maxSockets: 20, freeSocketTimeout: 60000}
 , BASE_BACKOFF_MILLIS: 3000
 , MAX_BACKOFF_MILLIS: 30000
-, MAX_ATTEMPS: -1
+, MAX_ATTEMPTS: -1
 , DEFAULT_REQUEST_TIMEOUT: 30000
 , USER_AGENT: `${pkg.name}/${pkg.version}`
 , FLUSH_BYTE_LIMIT: 5000000

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,6 +21,7 @@ const kMeta = Symbol('meta')
 const kIsLoggingBackedOff = Symbol.for('isLoggingBackedOff')
 const kFlusher = Symbol('flusher')
 const kAttempts = Symbol('attempts')
+const kMaxAttempts = Symbol('maxAttempts')
 const kRequestDefaults = Symbol.for('requestDefaults')
 const kReadyToSend = Symbol.for('readyToSend')
 const kIsSending = Symbol.for('isSending')
@@ -87,6 +88,7 @@ class Logger extends EventEmitter {
     this[kMeta] = {}
     this[kIsLoggingBackedOff] = false
     this[kAttempts] = 0
+    this[kMaxAttempts] = constants.MAX_ATTEMPTS
     this[kRequestDefaults] = undefined
     this[kFlusher] = null
     this[kReadyToSend] = []
@@ -356,6 +358,15 @@ class Logger extends EventEmitter {
 
     if (has(options, 'ignoreRetryableErrors')) {
       this[kIgnoreRetryableErrors] = Boolean(options.ignoreRetryableErrors)
+    }
+
+    if (has(options, 'maxAttempts')) {
+      if (!Number.isInteger(options.maxAttempts)) {
+        const err = new TypeError('maxAttempts must be an integer')
+        err.meta = {got: options.maxAttempts}
+        throw err
+      }
+      this[kMaxAttempts] = options.maxAttempts
     }
 
     if (has(options, 'sendUserAgent')) {
@@ -657,6 +668,13 @@ class Logger extends EventEmitter {
     })
   }
 
+  _shouldRetry(code) {
+    if ((this[kMaxAttempts] >= 0) && (this[kAttempts] >= this[kMaxAttempts])) {
+      return false
+    }
+    return ERROR_CODES_TO_RETRY.has(code)
+  }
+
   send(calledByFlush = true) {
     if (this[kIsSending] && calledByFlush) return
     this[kIsSending] = true
@@ -772,7 +790,8 @@ class Logger extends EventEmitter {
               ? error.response.status
               : error.code // timeouts will populate this
 
-            const retrying = ERROR_CODES_TO_RETRY.has(code)
+            ++this[kAttempts]
+            const retrying = this._shouldRetry(code)
             const {Authorization: _, ...headers} = config.headers
             const errorMeta = {
               actual: error.message
@@ -780,7 +799,7 @@ class Logger extends EventEmitter {
             , firstLine
             , lastLine
             , retrying
-            , attempts: ++this[kAttempts]
+            , attempts: this[kAttempts]
             , headers
             , url: config.url
             }

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -26,6 +26,7 @@ module.exports = function createOptions({
 , proxy = undefined
 , ignoreRetryableErrors = undefined
 , sendUserAgent = undefined
+, maxAttempts = undefined
 } = {}) {
   return {
     key
@@ -52,5 +53,6 @@ module.exports = function createOptions({
   , proxy
   , ignoreRetryableErrors
   , sendUserAgent
+  , maxAttempts
   }
 }

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -49,6 +49,7 @@ test('Logger instance properties', async (t) => {
     , 'Symbol(isSending)': false
     , 'Symbol(totalLinesReady)': 0
     , 'Symbol(backoffMs)': 3000
+    , 'Symbol(maxAttempts)': -1
     , 'Symbol(payloadStructure)': 'default'
     , 'Symbol(compress)': false
     , 'Symbol(ignoreRetryableErrors)': true

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -11,7 +11,7 @@ test('Exports structure', async (t) => {
   t.equal(Logger.name, 'Logger', 'Class name is correct')
 
   const methods = Object.getOwnPropertyNames(Logger.prototype)
-  t.equal(methods.length, 9, 'Logger.prototype prop count')
+  t.equal(methods.length, 10, 'Logger.prototype prop count')
   t.same(methods, [
     'constructor'
   , 'addMetaProperty'
@@ -21,6 +21,7 @@ test('Exports structure', async (t) => {
   , '_getSendPayload'
   , 'log'
   , 'removeMetaProperty'
+  , '_shouldRetry'
   , 'send'
   ], 'Methods names as expected')
 })
@@ -522,6 +523,20 @@ test('Instantiation Errors', async (t) => {
     , meta: {
         got: 50
       , baseBackoffMs: 200
+      }
+    }, 'Expected error thrown')
+  })
+
+  t.test('Bad maxAttempts', async (t) => {
+    t.throws(() => {
+      return new Logger(apiKey, {
+        maxAttempts: 'NOPE'
+      })
+    }, {
+      message: 'maxAttempts must be an integer'
+    , name: 'TypeError'
+    , meta: {
+        got: 'NOPE'
       }
     }, 'Expected error thrown')
   })

--- a/types.d.ts
+++ b/types.d.ts
@@ -31,6 +31,7 @@ declare module "@logdna/logger" {
     withCredentials?: boolean;
     sendUserAgent?: boolean;
     levels?: CustomLevel[];
+    maxAttempts?: number;
   }
 
   interface LogOptions {


### PR DESCRIPTION
Allow users to optionally specify a maximum number of
attempts to send in case of retryable errors, instead
of retrying indefinitely.

* The logger will accept an integer "maxAttempts" option,
  which gives the _total_ number of attempts (including
  the first) when retryable errors are encountered.
* When the limit is reached, errors that would otherwise
  be considered retryable are instead treated as non-retryable.
* If "maxAttempts" is negative (or not specified),
  the logger will continue to retry indefinitely.

* lib/logger.js: Add definitions and initialization for
maxAttempts.  Add convenience method _shouldRetry() to
determine whether or not to retry given a specific
error code.

* lib/constants.js: Add MAX_ATTEMPTS default value.

* test/logger-errors.js: Add a test to verify that retries
are limited.

* test/logger-instantiation.js: Add a test for maxAttempts
option validation.

* test/common/create-options.js: Update test support code.