### PR TITLE
feat: optionally include buffer in send/error events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ For those cases, additional properties (apart from `message`) are included:
     * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
     * `maxAttempts` [`<Number>`][] - Maximum number of times the logger will try to send a buffer of messages when retryable errors are encountered; when the limit is reached, retryable errors will be treated as non-retryable errors.  **Default:** `-1`, meaning unlimited.
     * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
-    * `verboseEvents` [`<Boolean>`][] - Include the complete content of the buffer sent when emitting `send` and `error` events.  When this option is enabled, the events will include an additional `buffer` field which is an array of the messages and any metadata associated with those messages that were involved in the transmission that triggered the event.
+    * `verboseEvents` [`<Boolean>`][] - Include the complete content of the buffer sent when emitting `send` and `error` events.  When this option is enabled, the events will include an additional `buffer` field which is an array of the messages and any metadata associated with those messages that were involved in the transmission that triggered the event.  **Default:** `false`
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
     * `proxy` [`<String>`][] - The full URL of an http or https proxy to pass through

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ For those cases, additional properties (apart from `message`) are included:
     * `maxBackoffMs` [`<Number>`][] - Maximum exponential backoff time in milliseconds. **Default:** `30000`ms
     * `maxAttempts` [`<Number>`][] - Maximum number of times the logger will try to send a buffer of messages when retryable errors are encountered; when the limit is reached, retryable errors will be treated as non-retryable errors.  **Default:** `-1`, meaning unlimited.
     * `withCredentials` [`<Boolean>`][] - Passed to the request library to make CORS requests. **Default:** `false`
+    * `verboseEvents` [`<Boolean>`][] - Include the complete content of the buffer sent when emitting `send` and `error` events.  When this option is enabled, the events will include an additional `buffer` field which is an array of the messages and any metadata associated with those messages that were involved in the transmission that triggered the event.
     * `payloadStructure` [`<String>`][] - (*LogDNA usage only*) Ability to specify a different payload structure for ingestion. **Default:** `default`
     * `compress` [`<Boolean>`][] - (*LogDNA usage only*) Compression support for the agent. **Default:** `false`
     * `proxy` [`<String>`][] - The full URL of an http or https proxy to pass through

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ const kMeta = Symbol('meta')
 const kIsLoggingBackedOff = Symbol.for('isLoggingBackedOff')
 const kFlusher = Symbol('flusher')
 const kAttempts = Symbol('attempts')
-const kMaxAttempts = Symbol('maxAttempts')
+const kMaxAttempts = Symbol.for('maxAttempts')
 const kRequestDefaults = Symbol.for('requestDefaults')
 const kReadyToSend = Symbol.for('readyToSend')
 const kIsSending = Symbol.for('isSending')
@@ -30,6 +30,7 @@ const kBackoffMs = Symbol('backoffMs')
 const kPayloadStructure = Symbol('payloadStructure')
 const kCompress = Symbol('compress')
 const kIgnoreRetryableErrors = Symbol.for('ignoreRetryableErrors')
+const kVerboseEvents = Symbol.for('verboseEvents')
 const kUserAgentHeader = Symbol.for('userAgentHeader')
 const kLogLevels = Symbol.for('levels')
 
@@ -98,6 +99,7 @@ class Logger extends EventEmitter {
     this[kPayloadStructure] = constants.PAYLOAD_STRUCTURES.DEFAULT
     this[kCompress] = false
     this[kIgnoreRetryableErrors] = true
+    this[kVerboseEvents] = false
     this[kLogLevels] = constants.LOG_LEVELS
 
     let useHttps = true
@@ -358,6 +360,10 @@ class Logger extends EventEmitter {
 
     if (has(options, 'ignoreRetryableErrors')) {
       this[kIgnoreRetryableErrors] = Boolean(options.ignoreRetryableErrors)
+    }
+
+    if (has(options, 'verboseEvents')) {
+      this[kVerboseEvents] = Boolean(options.verboseEvents)
     }
 
     if (has(options, 'maxAttempts')) {
@@ -740,29 +746,50 @@ class Logger extends EventEmitter {
           // We have a 200-level success code.
           let totalLinesSent = buffer.length
 
+          this[kIsLoggingBackedOff] = false
+          this[kAttempts] = 0
+          this[kIsSending] = false
+          this[kTotalLinesReady] -= buffer.length
+
           if (response.status === PARTIAL_SUCCESS_CODE) {
             const statusCodes = response.data.status || []
-
+            let goodLines = 0
             for (let i = 0; i < statusCodes.length; i++) {
-              if (statusCodes[i] === SUCCESS_CODE) continue
+              if (statusCodes[i] === SUCCESS_CODE) {
+                // This will effectively elide the failed lines from
+                // buffer, so if verboseEvents is enabled the 'send'
+                // event will include only the sent lines.
+
+                buffer[goodLines++] = buffer[i]
+                continue
+              }
               totalLinesSent--
               const err = new Error(LINE_INGEST_ERROR)
               err.meta = {
                 statusCode: statusCodes[i]
               , line: buffer[i].line
+              , ...(this[kVerboseEvents] && {buffer: [buffer[i]]})
               }
               this.emit('error', err)
             }
+
+            // Truncate the buffer length to the count of good lines, dumping
+            // the (now) duplicates left at the end by the shifting we did
+            // above.
+
+            buffer.length = goodLines
           }
 
-          this[kIsLoggingBackedOff] = false
-          this[kAttempts] = 0
-          this[kIsSending] = false
-          this[kTotalLinesReady] -= buffer.length
+          // Remove the buffer from readyToSend.
+
           this[kReadyToSend].shift()
 
-          // Assist GC by killing the buffer and removing it from readyToSend
-          buffer.length = 0
+          if (!this[kVerboseEvents]) {
+            // Assist GC by killing the buffer, unless the user has
+            // requested that the buffer be included in the send event.
+
+            buffer.length = 0
+          }
 
           this.emit('send', {
             httpStatus: response.status
@@ -771,6 +798,7 @@ class Logger extends EventEmitter {
           , totalLinesSent
           , totalLinesReady: this[kTotalLinesReady]
           , bufferCount: this[kReadyToSend].length
+          , ...(this[kVerboseEvents] && {buffer})
           })
 
           if (this[kReadyToSend].length) {
@@ -802,6 +830,7 @@ class Logger extends EventEmitter {
             , attempts: this[kAttempts]
             , headers
             , url: config.url
+            , ...(this[kVerboseEvents] && {buffer})
             }
 
             if (retrying) {
@@ -839,7 +868,14 @@ class Logger extends EventEmitter {
             this[kTotalLinesReady] -= buffer.length
             this[kAttempts] = 0
             this[kReadyToSend].shift()
-            buffer.length = 0
+
+            if (!this[kVerboseEvents]) {
+              // Assist GC by killing the buffer, unless the user has
+              // requested that the buffer be included in the error event.
+
+              buffer.length = 0
+            }
+
             if (this[kReadyToSend].length) {
               this.send()
               return

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -27,6 +27,7 @@ module.exports = function createOptions({
 , ignoreRetryableErrors = undefined
 , sendUserAgent = undefined
 , maxAttempts = undefined
+, verboseEvents = undefined
 } = {}) {
   return {
     key
@@ -54,5 +55,6 @@ module.exports = function createOptions({
   , ignoreRetryableErrors
   , sendUserAgent
   , maxAttempts
+  , verboseEvents
   }
 }

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -53,6 +53,7 @@ test('Logger instance properties', async (t) => {
     , 'Symbol(payloadStructure)': 'default'
     , 'Symbol(compress)': false
     , 'Symbol(ignoreRetryableErrors)': true
+    , 'Symbol(verboseEvents)': false
     , 'Symbol(userAgentHeader)': constants.USER_AGENT
     , 'Symbol(levels)': constants.LOG_LEVELS
     , 'Symbol(requestDefaults)': {
@@ -168,6 +169,18 @@ test('Logger instance properties', async (t) => {
     , 'ignoreRetryableErrors is true'
     )
 
+    t.equal(
+      log[Symbol.for('verboseEvents')]
+    , false
+    , 'verboseEvents is false'
+    )
+
+    t.equal(
+      log[Symbol.for('maxAttempts')]
+    , -1
+    , 'maxAttempts is -1'
+    )
+
     t.match(log, {
       flushLimit: 5000000
     , flushIntervalMs: 250
@@ -202,7 +215,9 @@ test('Logger instance properties', async (t) => {
     , mac: '01:02:03:04:05:06'
     , tags: ['whiz', null, undefined, '', ' ', '\t', '\n', 'bang', 'done', 1234, 0]
     , ignoreRetryableErrors: false
+    , verboseEvents: true
     , sendUserAgent: false
+    , maxAttempts: 5
     })
     const log = new Logger(apiKey, options)
 
@@ -239,6 +254,19 @@ test('Logger instance properties', async (t) => {
       log[Symbol.for('ignoreRetryableErrors')]
     , false
     , 'ignoreRetryableErrors was set correctly'
+    )
+
+    console.log({log}, 'log content')
+    t.equal(
+      log[Symbol.for('maxAttempts')]
+    , 5
+    , 'maxAttempts was set correctly'
+    )
+
+    t.equal(
+      log[Symbol.for('verboseEvents')]
+    , true
+    , 'verboseEvents was set correctly'
     )
   })
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,6 +32,8 @@ declare module "@logdna/logger" {
     sendUserAgent?: boolean;
     levels?: CustomLevel[];
     maxAttempts?: number;
+    verboseEvents?: boolean;
+    ignoreRetryableErrors?: boolean;
   }
 
   interface LogOptions {


### PR DESCRIPTION
With this change, the user may specify a `verboseEvents`
boolean option when creating a logger.  If true, the logger
will include the buffer of messages that was sent (or attempted
to be sent) when emitting `send` and `error` events, in the
`buffer` member of the `send` event and the `meta.buffer` member
of the `error` event.  This enables users to correctly identify
the messages that were transmitted for metrics in case of success,
and to implement higher-level retry behaviors in case of errors.

* lib/logger.js: Add support for `verboseEvents` option.
(send): When emitting `send` and `error` events, include the
message buffer involved when `verboseEvents` is true.  In case
of partial success, each `error` event will include a buffer
containing only the specific line that failed; and the corresponding
`send` event will include a buffer containing only those lines that
were sent successfully.

* test/common/create-options.js:
* test/logger-errors.js:
* test/logger-instantiation.js:
* test/logger-log.js: Add tests for `verboseEvents`.

* README.md:
* types.d.ts: Update readme and type definitions.

Fixes: #60 