### PR TITLE
chore(deps): axios@0.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@logdna/stdlib": "^1.1.5",
     "agentkeepalive": "^4.1.3",
-    "axios": "^0.21.1",
+    "axios": "^0.25.0",
     "https-proxy-agent": "^5.0.0",
     "json-stringify-safe": "^5.0.1"
   },


### PR DESCRIPTION
This fixes an identified security vulerability in one of
axios' dependencies, `follow-redirects`.

Fixes: #63