### PR TITLE
feat: allow user to disable log level validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ For those cases, additional properties (apart from `message`) are included:
 * `options` [`<Object>`][]
     * `level` [`<String>`][] - [Level](#default-log-levels) to be used if not specified elsewhere. **Default:** `INFO`
     * `levels` [`<Array>`][] - An array of custom log levels to use. **Default:** [Default log levels](#default-log-levels)
+    * `validateLogLevels` [`<Boolean>`][] - If true, check that the log level specified in calls to `log()` are in the list of known log levels given by `levels`, and reject the line or coerce the level to the default `level` if the given log level is not known. **Default:** `true`
     * `tags` [`<Array>`][] | [`<String>`][] - Tags to be added to each message
     * `meta` [`<Object>`][] - Global metadata. Added to each message, unless overridden.
     * `timeout` [`<Number>`][] - Millisecond timeout for each HTTP request. **Default:** `30000`ms. **Max:** `300000`ms

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,6 +33,7 @@ const kIgnoreRetryableErrors = Symbol.for('ignoreRetryableErrors')
 const kVerboseEvents = Symbol.for('verboseEvents')
 const kUserAgentHeader = Symbol.for('userAgentHeader')
 const kLogLevels = Symbol.for('levels')
+const kValidateLogLevels = Symbol.for('validateLogLevels')
 
 const LEVEL_REGEX = /^[A-Za-z]+$/
 const ALL_CLEAR_SENT = 'All accumulated log entries have been sent'
@@ -101,6 +102,7 @@ class Logger extends EventEmitter {
     this[kIgnoreRetryableErrors] = true
     this[kVerboseEvents] = false
     this[kLogLevels] = constants.LOG_LEVELS
+    this[kValidateLogLevels] = true
 
     let useHttps = true
     let withCredentials = false
@@ -134,11 +136,15 @@ class Logger extends EventEmitter {
       this[kLogLevels] = custom_levels
     }
 
+    if (has(options, 'validateLogLevels')) {
+      this[kValidateLogLevels] = Boolean(options.validateLogLevels)
+    }
+
     createConvenienceMethods(Array.from(this[kLogLevels]), this)
 
     if (has(options, 'level')) {
       const level = options.level.toUpperCase()
-      if (!this[kLogLevels].includes(level)) {
+      if (this[kValidateLogLevels] && !this[kLogLevels].includes(level)) {
         const err = new Error('Invalid level')
         err.meta = {
           got: level
@@ -553,7 +559,7 @@ class Logger extends EventEmitter {
     if (typeof opts === 'string') {
       // Then it should be a log level string
       const level = opts.toUpperCase()
-      if (!this[kLogLevels].includes(level)) {
+      if (this[kValidateLogLevels] && !this[kLogLevels].includes(level)) {
         const err = new TypeError(
           'If \'options\' is a string, then it must be a valid log level'
         )
@@ -586,7 +592,7 @@ class Logger extends EventEmitter {
     if (has(opts, 'level')) {
       // They've passed in a `level`.  Validate it.
       const level = opts.level.toUpperCase()
-      if (this[kLogLevels].includes(level)) {
+      if (!this[kValidateLogLevels] || this[kLogLevels].includes(level)) {
         message.level = level
       } else {
         const err = new Error('Invalid log level.  Using the default instead.')

--- a/test/common/create-options.js
+++ b/test/common/create-options.js
@@ -28,6 +28,7 @@ module.exports = function createOptions({
 , sendUserAgent = undefined
 , maxAttempts = undefined
 , verboseEvents = undefined
+, validateLogLevels = undefined
 } = {}) {
   return {
     key
@@ -56,5 +57,6 @@ module.exports = function createOptions({
   , sendUserAgent
   , maxAttempts
   , verboseEvents
+  , validateLogLevels
   }
 }

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -56,6 +56,7 @@ test('Logger instance properties', async (t) => {
     , 'Symbol(verboseEvents)': false
     , 'Symbol(userAgentHeader)': constants.USER_AGENT
     , 'Symbol(levels)': constants.LOG_LEVELS
+    , 'Symbol(validateLogLevels)': true
     , 'Symbol(requestDefaults)': {
         auth: {
           username: apiKey
@@ -110,6 +111,15 @@ test('Logger instance properties', async (t) => {
     , 'CRITICAL'
     , 'CUSTOMLEVEL'
     ], 'custom levels were added')
+  })
+
+  t.test('Test custom default level with validation disabled', async (t) => {
+    const log = new Logger(apiKey, {
+      level: 'NOPE'
+    , levels: ['YEP']
+    , validateLogLevels: false
+    })
+    t.same(log.level, 'NOPE', 'unknown default level is allowed')
   })
 
   t.test('HTTP agent is assigned correctly based on proxies or not', async (t) => {
@@ -176,6 +186,12 @@ test('Logger instance properties', async (t) => {
     )
 
     t.equal(
+      log[Symbol.for('validateLogLevels')]
+    , true
+    , 'validateLogLevels is true'
+    )
+
+    t.equal(
       log[Symbol.for('maxAttempts')]
     , -1
     , 'maxAttempts is -1'
@@ -216,6 +232,7 @@ test('Logger instance properties', async (t) => {
     , tags: ['whiz', null, undefined, '', ' ', '\t', '\n', 'bang', 'done', 1234, 0]
     , ignoreRetryableErrors: false
     , verboseEvents: true
+    , validateLogLevels: false
     , sendUserAgent: false
     , maxAttempts: 5
     })
@@ -267,6 +284,12 @@ test('Logger instance properties', async (t) => {
       log[Symbol.for('verboseEvents')]
     , true
     , 'verboseEvents was set correctly'
+    )
+
+    t.equal(
+      log[Symbol.for('validateLogLevels')]
+    , false
+    , 'validateLogLevels was set correctly'
     )
   })
 

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -150,6 +150,60 @@ test('Test custom log levels, including send events', async (t) => {
   }
 })
 
+test('Test custom log levels without validation', async (t) => {
+  const opts = createOptions({
+    app: 'myApp'
+  , validateLogLevels: false
+  })
+  const logger = new Logger(apiKey, opts)
+  const logText = 'This is my log text'
+  const responseText = 'This is the ingester response'
+
+  t.test('calling logger.log() with string opts', (t) => {
+    // Validation happens at two points.  This test checks that we skip
+    // the check when validateLogLevels is false and the log level is passed
+    // as the one and only string for "opts" in the call to log().
+
+    t.on('end', async () => {
+      logger.removeAllListeners()
+      nock.cleanAll()
+    })
+
+    t.plan(1)
+    nock(opts.url)
+      .post('/', (body) => {
+        t.same(body.ls[0].level, 'CUSTOM_1')
+        return true
+      })
+      .query((qs) => { return true })
+      .reply(200, responseText)
+
+    logger.log(logText, 'custom_1')
+  })
+
+  t.test('calling logger.log() with object opts', (t) => {
+    // Validation happens at two points.  This test checks that we skip
+    // the check when validateLogLevels is false and the log level is passed
+    // as a member of the opts object.
+
+    t.on('end', async () => {
+      logger.removeAllListeners()
+      nock.cleanAll()
+    })
+
+    t.plan(1)
+    nock(opts.url)
+      .post('/', (body) => {
+        t.same(body.ls[0].level, 'CUSTOM_1')
+        return true
+      })
+      .query((qs) => { return true })
+      .reply(200, responseText)
+
+    logger.log(logText, {level: 'custom_1'})
+  })
+})
+
 test('Using an https:// url sends and https agent', (t) => {
   const logger = new Logger(apiKey, createOptions({
     url: 'https://localhost:8888'

--- a/types.d.ts
+++ b/types.d.ts
@@ -34,6 +34,7 @@ declare module "@logdna/logger" {
     maxAttempts?: number;
     verboseEvents?: boolean;
     ignoreRetryableErrors?: boolean;
+    validateLogLevels?: boolean;
   }
 
   interface LogOptions {


### PR DESCRIPTION
With this change, the user may specify `validateLogLevels: false` when
instantiating a logger in order to disable validation of log levels.
This is helpful in cases where the log levels are not known in advance.
If `validateLogLevels` is true, the logger behaves as it does now:
unrecognized values for the log level are detected and the associated
line is rejected, or the log level is coerced to the default value.

* lib/logger.js: Add support for `validateLogLevels` option.

* test/common/create-options.js:
* test/logger-instantiation.js:
* test/logger-log.js: Add tests for `validateLogLevels`.

* README.md:
* types.d.ts: Update readme and type definitions.

Fixes: #65