### PR TITLE
refactor: extract _getPayloadSize method

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -469,8 +469,12 @@ class Logger extends EventEmitter {
     this.bufferLog(payload)
   }
 
+  _getPayloadSize(payload) {
+    return payload.line.length
+  }
+
   bufferLog(payload) {
-    const lineLength = payload.line.length
+    const lineLength = this._getPayloadSize(payload)
 
     this[kLineLengthTotal] += lineLength
     this[kBuffer].push(payload)

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -11,11 +11,12 @@ test('Exports structure', async (t) => {
   t.equal(Logger.name, 'Logger', 'Class name is correct')
 
   const methods = Object.getOwnPropertyNames(Logger.prototype)
-  t.equal(methods.length, 10, 'Logger.prototype prop count')
+  t.equal(methods.length, 11, 'Logger.prototype prop count')
   t.same(methods, [
     'constructor'
   , 'addMetaProperty'
   , 'agentLog'
+  , '_getPayloadSize'
   , 'bufferLog'
   , 'flush'
   , '_getSendPayload'


### PR DESCRIPTION
* lib/logger.js: Extract logic for computing size of
a payload to a separate function so it can be overridden
or expanded cleanly (for example if we choose to start
measuring the size of the entire payload object instead
of just the length of the log message).

* test/logger-instantiation.js: Update tests relating to
count and set of methods in Logger.

No other test changes since _getPayloadSize is a trivial
internal utility function at this time.