### PR TITLE
refactor: extract _serializeBuffer method

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -685,6 +685,10 @@ class Logger extends EventEmitter {
     return ERROR_CODES_TO_RETRY.has(code)
   }
 
+  _serializeBuffer(buffer) {
+    return stringify({e: 'ls', ls: buffer})
+  }
+
   send(calledByFlush = true) {
     if (this[kIsSending] && calledByFlush) return
     this[kIsSending] = true
@@ -726,7 +730,7 @@ class Logger extends EventEmitter {
       ? buffer[buffer.length - 1].line
       : null
 
-    const data = stringify({e: 'ls', ls: buffer})
+    const data = this._serializeBuffer(buffer)
 
     this._getSendPayload(data, (error, payload) => {
       if (error) {

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -11,18 +11,19 @@ test('Exports structure', async (t) => {
   t.equal(Logger.name, 'Logger', 'Class name is correct')
 
   const methods = Object.getOwnPropertyNames(Logger.prototype)
-  t.equal(methods.length, 11, 'Logger.prototype prop count')
-  t.same(methods, [
-    'constructor'
+  t.equal(methods.length, 12, 'Logger.prototype prop count')
+  t.same(methods.sort(), [
+    '_getPayloadSize'
+  , '_getSendPayload'
+  , '_serializeBuffer'
+  , '_shouldRetry'
   , 'addMetaProperty'
   , 'agentLog'
-  , '_getPayloadSize'
   , 'bufferLog'
+  , 'constructor'
   , 'flush'
-  , '_getSendPayload'
   , 'log'
   , 'removeMetaProperty'
-  , '_shouldRetry'
   , 'send'
   ], 'Methods names as expected')
 })


### PR DESCRIPTION
* lib/logger.js: Extract logic for creating a
serialized representation of the buffer to be
sent to a separate function, so we may cleanly
augment or override it in the future (for example
if we want to add a signature or checksum to the
transmitted data).

* test/logger-instantiation.js: Update tests relating
to count and set of methods in Logger; sort the list of
methods so we can predict the order without having to
run the test once when adding methods.

No explicit test for the extracted function at this
point since it's a trivial internal utility, and the
format returned is implicitly tested by existing tests.