### PR TITLE
fix(send): Allow _serializeBuffer() to be async

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -730,171 +730,184 @@ class Logger extends EventEmitter {
       ? buffer[buffer.length - 1].line
       : null
 
-    const data = this._serializeBuffer(buffer)
-
-    this._getSendPayload(data, (error, payload) => {
-      if (error) {
-        const err = new Error('Error gzipping data')
-        err.meta = {
-          message: 'Will attempt to send data uncompressed'
-        , error
-        }
-        // We will still send, but without compression
-        /* eslint no-unused-vars:0 */
-        const {'Content-Encoding': _, ...headers} = config.headers
-        config.headers = headers
-        config.data = data
-        this.emit('error', err)
-      } else {
-        config.data = payload
-      }
-
-      axios.request(config)
-        .then((response) => {
-          // We have a 200-level success code.
-          let totalLinesSent = buffer.length
-
-          this[kIsLoggingBackedOff] = false
-          this[kAttempts] = 0
-          this[kIsSending] = false
-          this[kTotalLinesReady] -= buffer.length
-
-          if (response.status === PARTIAL_SUCCESS_CODE) {
-            const statusCodes = response.data.status || []
-            let goodLines = 0
-            for (let i = 0; i < statusCodes.length; i++) {
-              if (statusCodes[i] === SUCCESS_CODE) {
-                // This will effectively elide the failed lines from
-                // buffer, so if verboseEvents is enabled the 'send'
-                // event will include only the sent lines.
-
-                buffer[goodLines++] = buffer[i]
-                continue
-              }
-              totalLinesSent--
-              const err = new Error(LINE_INGEST_ERROR)
-              err.meta = {
-                statusCode: statusCodes[i]
-              , line: buffer[i].line
-              , ...(this[kVerboseEvents] && {buffer: [buffer[i]]})
-              }
-              this.emit('error', err)
+    Promise.resolve(this._serializeBuffer(buffer))
+      .then((data) => {
+        this._getSendPayload(data, (error, payload) => {
+          if (error) {
+            const err = new Error('Error gzipping data')
+            err.meta = {
+              message: 'Will attempt to send data uncompressed'
+            , error
             }
-
-            // Truncate the buffer length to the count of good lines, dumping
-            // the (now) duplicates left at the end by the shifting we did
-            // above.
-
-            buffer.length = goodLines
-          }
-
-          // Remove the buffer from readyToSend.
-
-          this[kReadyToSend].shift()
-
-          if (!this[kVerboseEvents]) {
-            // Assist GC by killing the buffer, unless the user has
-            // requested that the buffer be included in the send event.
-
-            buffer.length = 0
-          }
-
-          this.emit('send', {
-            httpStatus: response.status
-          , firstLine
-          , lastLine
-          , totalLinesSent
-          , totalLinesReady: this[kTotalLinesReady]
-          , bufferCount: this[kReadyToSend].length
-          , ...(this[kVerboseEvents] && {buffer})
-          })
-
-          if (this[kReadyToSend].length) {
-            // Continue to send any backed up payloads that have accumulated
-            this.send()
-            return
-          }
-
-          this.emit('cleared', {
-            message: ALL_CLEAR_SENT
-          })
-        })
-        .catch((error) => {
-          // Allow the microtask queue to unwind in case it's a Promise rejection
-          process.nextTick(() => {
-            const code = error.response
-              ? error.response.status
-              : error.code // timeouts will populate this
-
-            ++this[kAttempts]
-            const retrying = this._shouldRetry(code)
-            const {Authorization: _, ...headers} = config.headers
-            const errorMeta = {
-              actual: error.message
-            , code
-            , firstLine
-            , lastLine
-            , retrying
-            , attempts: this[kAttempts]
-            , headers
-            , url: config.url
-            , ...(this[kVerboseEvents] && {buffer})
-            }
-
-            if (retrying) {
-              this[kIsLoggingBackedOff] = true
-              this[kBackoffMs] = backoffWithJitter(
-                this.baseBackoffMs
-              , this.maxBackoffMs
-              , this[kBackoffMs]
-              )
-              setTimeout(() => {
-                this.send(false)
-              }, this[kBackoffMs])
-
-              if (this[kIgnoreRetryableErrors]) return
-
-              const err = new Error(
-                'Temporary connection-based error. It will be retried. '
-                  + 'See meta data for details.'
-              )
-              err.meta = errorMeta
-              this.emit('error', err)
-
-              return
-            }
-
-            const err = new Error(
-              'A connection-based error occurred that will not be retried. '
-                + 'See meta data for details.'
-            )
-            err.meta = errorMeta
+            // We will still send, but without compression
+            /* eslint no-unused-vars:0 */
+            const {'Content-Encoding': _, ...headers} = config.headers
+            config.headers = headers
+            config.data = data
             this.emit('error', err)
+          } else {
+            config.data = payload
+          }
 
-            // User-level errors will be discarded since they will never succeed
-            this[kIsSending] = false
-            this[kTotalLinesReady] -= buffer.length
-            this[kAttempts] = 0
-            this[kReadyToSend].shift()
+          axios.request(config)
+            .then((response) => {
+              // We have a 200-level success code.
+              let totalLinesSent = buffer.length
 
-            if (!this[kVerboseEvents]) {
-              // Assist GC by killing the buffer, unless the user has
-              // requested that the buffer be included in the error event.
+              this[kIsLoggingBackedOff] = false
+              this[kAttempts] = 0
+              this[kIsSending] = false
+              this[kTotalLinesReady] -= buffer.length
 
-              buffer.length = 0
-            }
+              if (response.status === PARTIAL_SUCCESS_CODE) {
+                const statusCodes = response.data.status || []
+                let goodLines = 0
+                for (let i = 0; i < statusCodes.length; i++) {
+                  if (statusCodes[i] === SUCCESS_CODE) {
+                    // This will effectively elide the failed lines from
+                    // buffer, so if verboseEvents is enabled the 'send'
+                    // event will include only the sent lines.
 
-            if (this[kReadyToSend].length) {
-              this.send()
-              return
-            }
+                    buffer[goodLines++] = buffer[i]
+                    continue
+                  }
+                  totalLinesSent--
+                  const err = new Error(LINE_INGEST_ERROR)
+                  err.meta = {
+                    statusCode: statusCodes[i]
+                  , line: buffer[i].line
+                  , ...(this[kVerboseEvents] && {buffer: [buffer[i]]})
+                  }
+                  this.emit('error', err)
+                }
 
-            this.emit('cleared', {
-              message: ALL_CLEAR_SENT
+                // Truncate the buffer length to the count of good lines, dumping
+                // the (now) duplicates left at the end by the shifting we did
+                // above.
+
+                buffer.length = goodLines
+              }
+
+              // Remove the buffer from readyToSend.
+
+              this[kReadyToSend].shift()
+
+              if (!this[kVerboseEvents]) {
+                // Assist GC by killing the buffer, unless the user has
+                // requested that the buffer be included in the send event.
+
+                buffer.length = 0
+              }
+
+              this.emit('send', {
+                httpStatus: response.status
+              , firstLine
+              , lastLine
+              , totalLinesSent
+              , totalLinesReady: this[kTotalLinesReady]
+              , bufferCount: this[kReadyToSend].length
+              , ...(this[kVerboseEvents] && {buffer})
+              })
+
+              if (this[kReadyToSend].length) {
+                // Continue to send any backed up payloads that have accumulated
+                this.send()
+                return
+              }
+
+              this.emit('cleared', {
+                message: ALL_CLEAR_SENT
+              })
             })
-          })
+            .catch((error) => {
+              // Allow the microtask queue to unwind in case it's a Promise rejection
+              process.nextTick(() => {
+                const code = error.response
+                  ? error.response.status
+                  : error.code // timeouts will populate this
+
+                ++this[kAttempts]
+                const retrying = this._shouldRetry(code)
+                const {Authorization: _, ...headers} = config.headers
+                const errorMeta = {
+                  actual: error.message
+                , code
+                , firstLine
+                , lastLine
+                , retrying
+                , attempts: this[kAttempts]
+                , headers
+                , url: config.url
+                , ...(this[kVerboseEvents] && {buffer})
+                }
+
+                if (retrying) {
+                  this[kIsLoggingBackedOff] = true
+                  this[kBackoffMs] = backoffWithJitter(
+                    this.baseBackoffMs
+                  , this.maxBackoffMs
+                  , this[kBackoffMs]
+                  )
+                  setTimeout(() => {
+                    this.send(false)
+                  }, this[kBackoffMs])
+
+                  if (this[kIgnoreRetryableErrors]) return
+
+                  const err = new Error(
+                    'Temporary connection-based error. It will be retried. '
+                      + 'See meta data for details.'
+                  )
+                  err.meta = errorMeta
+                  this.emit('error', err)
+
+                  return
+                }
+
+                const err = new Error(
+                  'A connection-based error occurred that will not be retried. '
+                    + 'See meta data for details.'
+                )
+                err.meta = errorMeta
+                this.emit('error', err)
+
+                // User-level errors will be discarded since they will never succeed
+                this[kIsSending] = false
+                this[kTotalLinesReady] -= buffer.length
+                this[kAttempts] = 0
+                this[kReadyToSend].shift()
+
+                if (!this[kVerboseEvents]) {
+                  // Assist GC by killing the buffer, unless the user has
+                  // requested that the buffer be included in the error event.
+
+                  buffer.length = 0
+                }
+
+                if (this[kReadyToSend].length) {
+                  this.send()
+                  return
+                }
+
+                this.emit('cleared', {
+                  message: ALL_CLEAR_SENT
+                })
+              })
+            })
         })
-    })
+      })
+      .catch((error) => {
+        const err = new Error('Error serializing buffer')
+        const errorMeta = {
+          actual: error.message
+        , firstLine
+        , lastLine
+        , url: config.url
+        , ...(this[kVerboseEvents] && {buffer})
+        }
+        err.meta = errorMeta
+        this.emit('error', err)
+      })
   }
 }
 


### PR DESCRIPTION
* lib/logger.js: use Promise.resolve().then() to call _serializeBuffer,
so it can optionally be async in subclasses.

* test/logger-log.js:
* test/logger-errors.js: Add tests for async _serializeBuffer, and
error handling thereof.

Note: this _looks like_ a large change but it's not really -- just diff getting confused by the indentation changes
The substance of the change is to go from this:

```
const data = this._serializeBuffer(buffer)
// do stuff with data
```

to this:

```
Promise.resolve(this._serializeBuffer(buffer))
  .then((data) => {
    // do stuff with data
  })
  .catch((error) => {
    // Handle errors in resolution of _serializeBuffer
  })
```

I did not try to refactor the code in `// do stuff with data` because it's got a bit too much dependency on shared state vis a vis local variables.  I think it's possible to refactor it to make that a bit cleaner but I think that's out of scope for this change.