### PR TITLE
chore(deps): Install @logdna/commitlint-config@2.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,11 @@ def DEFAULT_BRANCH = 'main'
 def CHANGE_ID = env.CHANGE_ID == null ? '' : env.CHANGE_ID
 
 pipeline {
-  agent none
+  agent {
+    node {
+      label 'ec2-fleet'
+    }
+  }
 
   options {
     timestamps()
@@ -58,6 +62,7 @@ pipeline {
         agent {
           docker {
             image "us.gcr.io/logdna-k8s/node:${NODE_VERSION}"
+            label 'ec2-fleet'
           }
         }
 
@@ -90,7 +95,6 @@ pipeline {
 
     stage('Test Release') {
       when {
-        beforeAgent true
         not {
           branch DEFAULT_BRANCH
         }
@@ -100,6 +104,7 @@ pipeline {
         docker {
           image "us.gcr.io/logdna-k8s/node:17-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
+          label 'ec2-fleet'
         }
       }
 
@@ -118,7 +123,6 @@ pipeline {
 
     stage('Release') {
       when {
-        beforeAgent true
         branch DEFAULT_BRANCH
         not {
           changelog '\\[skip ci\\]'
@@ -129,6 +133,7 @@ pipeline {
         docker {
           image "us.gcr.io/logdna-k8s/node:17-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
+          label 'ec2-fleet'
         }
       }
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 * **[Using with AWS Lambda](#using-with-aws-lambda)**
 * **[Proxy Support](#proxy-support)**
 * **[License](#license)**
+* **[Contributing](#contributing)**
 
 ## Migrating From Other Versions
 
@@ -613,6 +614,16 @@ Copyright © [LogDNA](https://logdna.com), released under an MIT license. See th
 
 *Happy Logging!*
 
+## Contributing
+
+This project is open-sourced, and accepts PRs from the public for bugs or feature
+enhancements. These are the guidelines for contributing:
+
+* The project uses [Commitlint][] and enforces [Conventional Commit Standard][]. Please format your commits based on these guidelines.
+* An [issue must be opened](https://github.com/logdna/logger-node/issues) in the repository for any bug, feature, or anything else that will have a PR
+  * The commit message must reference the issue with an [acceptable action tag](https://github.com/logdna/commitlint-config/blob/41aef3b69f292e39fb41a5ef24bcd7043e0fceb3/index.js#L12-L20) in the commit footer, e.g. `Fixes: #5`
+
+
 [`<Boolean>`]: https://mdn.io/boolean
 [`<Number>`]: https://mdn.io/number
 [`<Object>`]: https://mdn.io/object
@@ -621,6 +632,8 @@ Copyright © [LogDNA](https://logdna.com), released under an MIT license. See th
 [`<TypeError>`]: https://mdn.io/TypeError
 [`<RangeError>`]: https://mdn.io/RangeError
 [`<Error>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+[Commitlint]: https://commitlint.js.org
+[Conventional Commit Standard]: https://www.conventionalcommits.org/en/v1.0.0/
 
 ## Contributors ✨
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "eslint": "^8.18.0",
     "eslint-config-logdna": "^6.1.0",
     "nock": "^13.1.3",
-    "semantic-release": "^17.4.7",
+    "semantic-release": "^19.0.3",
     "semantic-release-config-logdna": "^1.3.0",
     "tap": "^15.0.9",
     "tap-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-config-logdna": "^5.1.0",
+    "eslint": "^8.18.0",
+    "eslint-config-logdna": "^6.1.0",
     "nock": "^13.1.3",
     "semantic-release": "^17.4.7",
     "semantic-release-config-logdna": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run commitlint",
     "test": "tap",
     "pretest:ci": "npm run lint",
     "test:ci": "tools/test-ci.sh",
     "release": "semantic-release",
-    "release:dry": "semantic-release --dry-run --no-ci --branches=${BRANCH_NAME:-main}"
+    "release:dry": "semantic-release --dry-run --no-ci --branches=${BRANCH_NAME:-main}",
+    "commitlint": "commitlint --from=origin/main --to=HEAD"
   },
   "files": [
     "lib/",
@@ -72,6 +73,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "commitlint": {
+    "extends": [
+      "@logdna/commitlint-config"
+    ]
+  },
   "tap": {
     "100": true,
     "ts": false,
@@ -105,6 +111,8 @@
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {
+    "@logdna/commitlint-config": "^2.0.0",
+    "commitlint": "^17.0.3",
     "eslint": "^8.18.0",
     "eslint-config-logdna": "^6.1.0",
     "nock": "^13.1.3",

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -693,7 +693,8 @@ test('Retry-able error limit retries', (t) => {
         , retrying: false
         }
       ]
-    , 'retries eventually stop')
+    , 'retries eventually stop'
+    )
     t.end()
   })
   logger.log('This is a retryable error')

--- a/test/logger-log.js
+++ b/test/logger-log.js
@@ -805,7 +805,8 @@ test('removeMetaProperty() removes it from the payload; indexMeta: false', (t) =
   nock(logger.url)
     .post('/', (body) => {
       const payload = body.ls[0]
-      t.equal(payload.meta
+      t.equal(
+        payload.meta
       , '{"one":1,"three":3}'
       , 'meta property was removed from the message payload'
       )


### PR DESCRIPTION
**fix(ci): Specify agent label and remove `beforeAgent`**

These changes are necessary to conform to changes made to our
build system which segment the agents based on app concern.

Fixes: #72

---

**chore(deps): Install @logdna/commitlint-config@2.0.0**

This package will enforce Conventional commit style to be in line
with the Company's preference. Public PRs will have to adhere to
those standards for their commit messages.

Fixes: #72

---

**chore(deps): semantic-release@19.0.3**


---

**chore(deps): eslint@8.18.0 and eslint-config-logdna@6.1.0**
