### PR TITLE
fix(doc): Best practices code snipit does not work as an example

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
         axes {
           axis {
             name 'NODE_VERSION'
-            values '14', '16', '17'
+            values '14', '16', '18'
           }
         }
 
@@ -102,7 +102,7 @@ pipeline {
 
       agent {
         docker {
-          image "us.gcr.io/logdna-k8s/node:17-ci"
+          image "us.gcr.io/logdna-k8s/node:18-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
           label 'ec2-fleet'
         }
@@ -131,7 +131,7 @@ pipeline {
 
       agent {
         docker {
-          image "us.gcr.io/logdna-k8s/node:17-ci"
+          image "us.gcr.io/logdna-k8s/node:18-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
           label 'ec2-fleet'
         }

--- a/README.md
+++ b/README.md
@@ -505,14 +505,15 @@ if the HTTP calls becomes successful, they will begin to send immediately, and w
 ```javascript
 const {createLogger} = require('@logdna/logger')
 const {once} = require('events')
+const process = require('process')
 
-const logger = createLogger('<YOUR KEY HERE>')
+const logger = createLogger('This is not a real key and will cause an error')
 
 logger.on('error', console.error)
 
 function onSignal(signal) {
-  logger.warn({signal}, 'received signal, shutting down')
-  shutdown()
+  logger.warn(`received signal ${signal} shutting down`, {meta: {signal}})
+  shutdown().catch(() => {})
 }
 
 async function shutdown() {
@@ -521,6 +522,13 @@ async function shutdown() {
 
 process.on('SIGTERM', onSignal)
 process.on('SIGINT', onSignal)
+
+// For running this as a standalone example, an error will be shown due
+// to the key being invalid, but it shows the signal handler message
+// attempting to be sent for ingestion.
+setTimeout(() => {
+  process.kill(process.pid)
+}, 1000)
 ```
 
 ## Client Side


### PR DESCRIPTION
**fix(doc): Best practices code snipit does not work as an example**

The code snipit under "Best Practices" was meant to be a snipit for how
to configure an error listener, but it could be misconstrued as a
working example. This commit makes it work and disambiguates it.

Fixes: #74

---

**chore(ci): Test with node 18**

This starts testing node18 in the testing matrix.