### PR TITLE
fix: change from basic auth to apikey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 coverage/
 node_modules/
 .tap-output
+.nyc_output

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -403,7 +403,7 @@ class Logger extends EventEmitter {
     , agent
     , headers: {
         'Content-Type': 'application/json; charset=UTF-8'
-      , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
+      , 'apikey': `${key}`
       , ...compressHeader
       }
     , qs: {
@@ -828,7 +828,7 @@ class Logger extends EventEmitter {
 
                 ++this[kAttempts]
                 const retrying = this._shouldRetry(code)
-                const {Authorization: _, ...headers} = config.headers
+                const {apikey: _, ...headers} = config.headers
                 const errorMeta = {
                   actual: error.message
                 , code

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -65,7 +65,7 @@ test('Logger instance properties', async (t) => {
       , agent: Object
       , headers: {
           'Content-Type': 'application/json; charset=UTF-8'
-        , 'Authorization': /^Basic \w+/
+        , 'apikey': apiKey
         }
       , qs: {
           hostname: String


### PR DESCRIPTION
To be compatible with both pipeline and Analysis ingest, change to using the apikey header instead of basic auth.

Fixes: #86