### PR TITLE
fix: make compatible with pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 coverage/
 node_modules/
 .tap-output
+.nyc_output/

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -403,7 +403,7 @@ class Logger extends EventEmitter {
     , agent
     , headers: {
         'Content-Type': 'application/json; charset=UTF-8'
-      , 'Authorization': 'Basic ' + Buffer.from(`${key}:`).toString('base64')
+      , 'apiKey': key
       , ...compressHeader
       }
     , qs: {

--- a/test/logger-errors.js
+++ b/test/logger-errors.js
@@ -266,6 +266,7 @@ test('HTTP timeout will emit Error and continue to retry', (t) => {
   const expectedHeaders = {
     'Content-Type': 'application/json; charset=UTF-8'
   , 'user-agent': `${pkg.name}/${pkg.version}`
+  , 'apiKey': '< YOUR INGESTION KEY HERE >'
   }
 
   logger.on('error', (err) => {

--- a/test/logger-instantiation.js
+++ b/test/logger-instantiation.js
@@ -65,7 +65,7 @@ test('Logger instance properties', async (t) => {
       , agent: Object
       , headers: {
           'Content-Type': 'application/json; charset=UTF-8'
-        , 'Authorization': /^Basic \w+/
+        , 'apiKey': '< YOUR INGESTION KEY HERE >'
         }
       , qs: {
           hostname: String


### PR DESCRIPTION
Change auth schema to be apiKey so that
it works with both log analysis and pipeline

Fixes: #86