### PR TITLE
fix(pkg): Export `LogLevel` to satisfy typescript defs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,17 @@ function createLogger(key, options) {
   return new Logger(key, options)
 }
 
+const LogLevel = {
+  trace: 'TRACE'
+, debug: 'DEBUG'
+, info: 'INFO'
+, warn: 'WARN'
+, error: 'ERROR'
+, fatal: 'FATAL'
+}
+
 module.exports = {
   createLogger
 , setupDefaultLogger
+, LogLevel
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,10 +5,18 @@ const index = require('../index.js')
 const {apiKey, createOptions} = require('./common/index.js')
 
 test('Index exports are correct', async (t) => {
-  t.equal(Object.keys(index).length, 2, 'property count is correct')
+  t.equal(Object.keys(index).length, 3, 'property count is correct')
   t.match(index, {
     createLogger: Function
   , setupDefaultLogger: Function
+  , LogLevel: {
+      trace: 'TRACE'
+    , debug: 'DEBUG'
+    , info: 'INFO'
+    , warn: 'WARN'
+    , error: 'ERROR'
+    , fatal: 'FATAL'
+    }
   }, 'Exported properties are correct')
 })
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,12 +1,13 @@
 declare module "@logdna/logger" {
   import { EventEmitter } from 'events';
-  enum LogLevel {
-    trace,
-    debug,
-    info,
-    warn,
-    error,
-    fatal
+
+  export enum LogLevel {
+    trace = 'TRACE',
+    debug = 'DEBUG',
+    info = 'INFO',
+    warn = 'WARN',
+    error = 'ERROR',
+    fatal = 'FATAL'
   }
 
   type CustomLevel = string


### PR DESCRIPTION
Even though this project isn't ESM or typescript, we support a definitions file for it. In it, we define `LogLevel` as an enum, but it's not officially exported as such. This commit fixes the typescript definition to export that enum, as well as export it from the CommonJS entrypoint.

Fixes: #47