### PR TITLE
fix(cve): bump axios 1.17.0 to fix multiple cves

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@logdna/stdlib": "^1.2.3",
     "agentkeepalive": "^4.1.3",
-    "axios": "^1.7.4",
+    "axios": "^1.17.0",
     "https-proxy-agent": "^7.0.2",
     "json-stringify-safe": "^5.0.1"
   },


### PR DESCRIPTION
This bumps axios to 1.17.0 fixing multiple CVEs.

- CVE-2026-44495
- CVE-2026-44494
- CVE-2026-44492

Ref: VM-644
Ref: VM-645
Ref: VM-646